### PR TITLE
Adds build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/DFE-Digital/govuk-rails-boilerplate.svg?branch=master)](https://travis-ci.com/DFE-Digital/govuk-rails-boilerplate)
+[![Build Status](https://travis-ci.com/DFE-Digital/curriculum-materials.svg?branch=master)](https://travis-ci.com/DFE-Digital/curriculum-materials)
 
 # GOV.UK Rails Boilerplate
 


### PR DESCRIPTION
### Context
The build status badge on the repo wasn't wired up

### Changes proposed in this pull request
Wire up the badge in the readme

### Guidance to review
Readme badge should be wired up

