### PR TITLE
Add an endpoint that errors for Sentry testing

### DIFF
--- a/app/controllers/sentry_test_controller.rb
+++ b/app/controllers/sentry_test_controller.rb
@@ -1,0 +1,6 @@
+# Delete this once we've established Sentry is working
+class SentryTestController < ApplicationController
+  def show
+    fail
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
   get "/pages/:page", to: "pages#show"
 
-
   resource :home, only: %i(show)
   root to: 'home#show'
+
+  resource :sentry_test, controller: :sentry_test, only: %i(show)
 
   get "/404", to: "errors#not_found", via: :all
   get "/422", to: "errors#unprocessable_entity", via: :all


### PR DESCRIPTION
Add an endpoint that always fails so we can test Sentry integration
