### PR TITLE
Code climate integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ install:
   - yarn
 before_script:
   - bundle exec rake db:create db:migrate RAILS_ENV=test
+
+  # code climate's coverage check reporter
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
   - bundle exec rails webpacker:compile
   - bundle exec rake
@@ -24,3 +29,6 @@ deploy:
   app: govuk-rails-boilerplate
   on:
     repo: DFE-Digital/govuk-rails-boilerplate
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build Status](https://travis-ci.com/DFE-Digital/curriculum-materials.svg?branch=master)](https://travis-ci.com/DFE-Digital/curriculum-materials)
+[![Maintainability](https://api.codeclimate.com/v1/badges/347204b90ba1609c51df/maintainability)](https://codeclimate.com/github/DFE-Digital/curriculum-materials/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/347204b90ba1609c51df/test_coverage)](https://codeclimate.com/github/DFE-Digital/curriculum-materials/test_coverage)
 
 # GOV.UK Rails Boilerplate
 


### PR DESCRIPTION
Add integration with Code Climate, including allowing Travis to push coverage results.

The project's profile page is [here](https://codeclimate.com/github/DFE-Digital/curriculum-materials).