### PR TITLE
Disable rubocop autocorrect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ Metrics/BlockLength:
   Exclude:
     - config/environments/**/*.rb
 
+Naming/MethodParameterName:
+  Enabled: false
+
 Style/StringLiterals:
   Enabled: false
 Style/TrailingCommaInArguments:
@@ -17,6 +20,4 @@ Style/TrailingCommaInArguments:
 Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingCommaInArrayLiteral:
-  Enabled: false
-Naming/MethodParameterName:
   Enabled: false

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :set_raven_context
 
-  private
+private
 
   def set_raven_context
     Raven.user_context(id: session[:current_user_id])

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -2,7 +2,7 @@ desc "Lint ruby code"
 namespace :lint do
   task ruby: :environment do
     puts "Linting ruby..."
-    system "bundle exec rubocop app config db lib spec Gemfile --format clang -a"
+    system "bundle exec rubocop app config db lib spec Gemfile --format clang"
   end
 
   task scss: :environment do


### PR DESCRIPTION
Stop RuboCop from [autocorrecting](https://rubocop.readthedocs.io/en/latest/auto_correct/) code on the fly.

Also, fix indentation and organise cop settings alphabetically
