### PR TITLE
CSS-grid cards experiments 👨‍🔬

### DIFF
--- a/app/views/complete_curriculum_programmes/_unit_card.slim
+++ b/app/views/complete_curriculum_programmes/_unit_card.slim
@@ -10,4 +10,6 @@ article.card
     ol
       - unit.lessons.each do |lesson|
         li = link_to(lesson.name, lesson_path(lesson))
+
+  .card-footer
     = link_to 'View and plan lessons', unit_path(unit)

--- a/app/views/complete_curriculum_programmes/_unit_card.slim
+++ b/app/views/complete_curriculum_programmes/_unit_card.slim
@@ -7,9 +7,9 @@ article.card
 
   .card-body
     p.govuk-body = unit.overview
-    ol
+    ul
       - unit.lessons.each do |lesson|
-        li = link_to(lesson.name, lesson_path(lesson))
+        li = lesson.name
 
   .card-footer
     = link_to 'View and plan lessons', unit_path(unit)

--- a/app/webpacker/styles/_cards.scss
+++ b/app/webpacker/styles/_cards.scss
@@ -1,13 +1,10 @@
 .cards-container {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
   counter-reset: card-number;
-  gap: 2rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-gap: 1rem;
 
   .card {
-    flex: 0 0 30%;
-    flex-basis: 16rem;
     margin: 0.5rem 0;
     padding: 20px;
     padding-top: 10px;
@@ -15,15 +12,20 @@
     border-top: 10px solid govuk-colour("light-green");
     background-color: govuk-colour("light-grey");
 
+    display: grid;
+    grid-template-rows: auto 1fr auto auto;
+    grid-gap: 1rem;
+
+    a {
+      text-decoration: none;
+    }
+
     .card-header {
       display: flex;
       flex-direction: row;
       align-items: center;
-      justify-content: center;
 
       &::before {
-        flex-basis: 20%;
-        flex-grow: 0;
         counter-increment: card-number;
         content: counter(card-number);
         @extend %govuk-heading-xl;
@@ -31,12 +33,10 @@
         font-size: 4.5rem;
         padding: 0;
         margin: 0;
+        width: 3rem;
       }
 
       .card-header-title {
-        flex-grow: 1;
-        display: flex;
-        flex-direction: column;
         padding-left: 0.5rem;
 
         a > h3 {

--- a/app/webpacker/styles/_cards.scss
+++ b/app/webpacker/styles/_cards.scss
@@ -12,10 +12,6 @@
     border-top: 10px solid govuk-colour("light-green");
     background-color: govuk-colour("light-grey");
 
-    display: grid;
-    grid-template-rows: auto 1fr auto auto;
-    grid-gap: 1rem;
-
     a {
       text-decoration: none;
     }

--- a/spec/features/complete_curriculum_programme_spec.rb
+++ b/spec/features/complete_curriculum_programme_spec.rb
@@ -31,7 +31,7 @@ feature 'Complete Curriculum Programme page', type: :feature do
           expect(page).to have_css 'h3', text: unit.name
           expect(page).to have_link 'View and plan lessons', href: unit_path(unit)
           unit.lessons.each do |lesson|
-            expect(page).to have_link(lesson.name, href: lesson_path(lesson))
+            expect(page).to have_css('li', text: lesson.name)
           end
         end
       end


### PR DESCRIPTION
This is an experimental branch exploring the use of CSS grid to layout the grid-like cards that represent units.

| Before | After |
| ---------| --------|
| ![Before](https://user-images.githubusercontent.com/128088/73455616-57633280-4368-11ea-9230-bea4eb46dd52.png) | ![After](https://user-images.githubusercontent.com/128088/73455643-61853100-4368-11ea-9021-9bea424846b2.png) [Full length screenshot](https://user-images.githubusercontent.com/128088/73458353-0a358f80-436d-11ea-98d9-e43a9b78c4a8.png) |


You can see the grid and subgrid in action here with guide markers; it's supported in Chrome and Firefox.

![Screenshot from 2020-01-30 13-45-25](https://user-images.githubusercontent.com/128088/73455906-d8222e80-4368-11ea-94bd-0004e58d75b7.png)

Users of older browsers will currently see a list rather than a grid.

![Screenshot from 2020-01-30 14-03-42](https://user-images.githubusercontent.com/128088/73456220-6c8c9100-4369-11ea-874c-5068c1e726e5.png)

Thoughts and feedback welcome!
