### PR TITLE
Breadcrumbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,8 @@ gem "strong_migrations", "~> 0.5"
 gem "slim-rails"
 gem "redcarpet"
 gem "sentry-raven"
-gem 'simple_ams'
+gem "simple_ams"
+gem "actionview-component"
 
 # FIXME we're using factorybot and faker for seed data, move them back to
 # development/test once we're up and running with real data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    actionview-component (1.8.1)
     activejob (6.0.2.1)
       activesupport (= 6.0.2.1)
       globalid (>= 0.3.6)
@@ -307,6 +308,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionview-component
   bootsnap (>= 1.1.0)
   brakeman (= 4.7.2)
   bullet (~> 6.1)

--- a/app/components/page/breadcrumbs_component.rb
+++ b/app/components/page/breadcrumbs_component.rb
@@ -1,0 +1,10 @@
+class Page::BreadcrumbsComponent < ActionView::Component::Base
+  attr_reader :crumbs, :current_page
+
+  def initialize(crumbs: {}, current_page:)
+    fail("Breadcrumbs must be a hash in the format of { page => href }") unless crumbs.is_a?(Hash)
+
+    @crumbs       = crumbs
+    @current_page = current_page
+  end
+end

--- a/app/components/page/breadcrumbs_component.slim
+++ b/app/components/page/breadcrumbs_component.slim
@@ -1,0 +1,8 @@
+div.govuk-breadcrumbs
+  ol.govuk-breadcrumbs__list
+    - crumbs.each do |name, href|
+      li.govuk-breadcrumbs__list-item
+        = link_to(name, href, class: 'govuk-breadcrumbs__link')
+
+    li.govuk-breadcrumbs__list-item aria-current='page'
+      = current_page

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,12 @@ module ApplicationHelper
     end
   end
 
+  def breadcrumbs(crumbs: {}, current_page:)
+    content_for(:breadcrumbs) do
+      render(Page::BreadcrumbsComponent, crumbs: crumbs, current_page: current_page)
+    end
+  end
+
   def govuk_chevron(colour = "currentColor")
     content_tag :svg, class: "govuk-button__start-icon", xmlns: "http://www.w3.org/2000/svg", width: "17.5", height: "19", viewBox: "0 0 33 40", role: "presentation", focusable: "false" do
       tag.path fill: colour, d: "M0 0h13l20 20-20 20H0l20-20z"

--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -1,0 +1,10 @@
+module LessonsHelper
+  def lessons_breadcrumbs(lesson)
+    {
+      lesson.unit.complete_curriculum_programme.name =>
+        complete_curriculum_programme_path(lesson.unit.complete_curriculum_programme),
+
+      lesson.unit.name => unit_path(lesson.unit)
+    }
+  end
+end

--- a/app/helpers/units_helper.rb
+++ b/app/helpers/units_helper.rb
@@ -1,0 +1,8 @@
+module UnitsHelper
+  def units_breadcrumbs(unit)
+    {
+      unit.complete_curriculum_programme.name =>
+        complete_curriculum_programme_path(unit.complete_curriculum_programme)
+    }
+  end
+end

--- a/app/views/complete_curriculum_programmes/show.slim
+++ b/app/views/complete_curriculum_programmes/show.slim
@@ -1,3 +1,5 @@
+- breadcrumbs(current_page: @complete_curriculum_programme.name)
+
 h1 = @complete_curriculum_programme.name
 
 section

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -13,6 +13,7 @@ html lang="en" class="govuk-template "
 
     .govuk-width-container
       = render 'layouts/shared/phase_banner'
+      = content_for :breadcrumbs
       = content_for :back_button
 
       main#main-content.govuk-main-wrapper[role="main"]

--- a/app/views/lessons/show.slim
+++ b/app/views/lessons/show.slim
@@ -1,3 +1,5 @@
+- breadcrumbs(crumbs: lessons_breadcrumbs(@lesson), current_page: @lesson.name)
+
 .govuk-grid-row
   .govuk-grid-column-full
     h1.govuk-heading-l

--- a/app/views/units/show.slim
+++ b/app/views/units/show.slim
@@ -1,3 +1,5 @@
+- breadcrumbs(crumbs: units_breadcrumbs(@unit), current_page: @unit.name)
+
 .govuk-grid-row
   .govuk-grid-column-full
     h1.govuk-heading-l

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,11 +9,12 @@ require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_mailbox/engine"
-require "action_text/engine"
+# require "action_text/engine"
 require "action_view/railtie"
 # require "action_cable/engine"
 # require "sprockets/railtie"
 require "rails/test_unit/railtie"
+require "action_view/component/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -28,7 +29,6 @@ module CurriculumMaterials
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-
     config.exceptions_app = routes
   end
 end

--- a/spec/components/page/breadcrumbs_component_spec.rb
+++ b/spec/components/page/breadcrumbs_component_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Page::BreadcrumbsComponent, type: :component do
+  let(:crumbs) do
+    { 'Eutheria': '/eutheria', 'Primates': '/eutheria/primates' }
+  end
+
+  let(:current_page) { 'Hominidae' }
+
+  describe 'attributes' do
+    subject { described_class.new(crumbs: crumbs, current_page: current_page) }
+
+    specify 'should set the crumbs and current page correctly' do
+      expect(subject.crumbs).to be(crumbs)
+      expect(subject.current_page).to be(current_page)
+    end
+  end
+
+  describe 'generated HTML' do
+    subject do
+      Capybara::Node::Simple.new(
+        render_inline(described_class, crumbs: crumbs, current_page: current_page).to_html
+      )
+    end
+
+    specify 'the output should comply with the GOV.UK Design System' do
+      expect(subject).to have_css('.govuk-breadcrumbs > ol.govuk-breadcrumbs__list')
+    end
+
+    specify 'the breadcrumbs should link to the correct paths' do
+      crumbs.each do |name, href|
+        expect(subject).to have_link(name, href: href)
+      end
+    end
+
+    specify 'the final breadcrumb (the current page) should not be a link' do
+      expect(subject).to have_css('li', text: current_page)
+      expect(subject).not_to have_link(current_page)
+    end
+  end
+end

--- a/spec/features/complete_curriculum_programme_spec.rb
+++ b/spec/features/complete_curriculum_programme_spec.rb
@@ -25,6 +25,12 @@ feature 'Complete Curriculum Programme page', type: :feature do
       expect(page).to have_css 'h1', text: complete_curriculum_programme.name
     end
 
+    it "contains breadcrumbs with only the current CCP included" do
+      within('.govuk-breadcrumbs') do
+        expect(page).to have_content(complete_curriculum_programme.name)
+      end
+    end
+
     context 'Unit cards' do
       it "shows a card for each unit" do
         units.each do |unit|

--- a/spec/features/lessons/show_spec.rb
+++ b/spec/features/lessons/show_spec.rb
@@ -3,11 +3,21 @@ require "rails_helper"
 RSpec.feature "Lesson page", type: :feature do
   describe '#show' do
     let(:lesson) { FactoryBot.create(:lesson) }
+    let(:unit) { lesson.unit }
+    let(:ccp) { unit.complete_curriculum_programme }
 
     before { visit(lesson_path(lesson)) }
 
     specify 'the page heading should be the lesson title' do
       expect(page).to have_css('h1', text: lesson.name)
+    end
+
+    specify "there should be breadcrumbs for the CCP and current unit" do
+      within('.govuk-breadcrumbs') do
+        expect(page).to have_link(ccp.name, href: complete_curriculum_programme_path(ccp))
+        expect(page).to have_link(unit.name, href: unit_path(unit))
+        expect(page).to have_content(lesson.name)
+      end
     end
 
     specify 'there should be the correct sections' do

--- a/spec/features/units/show_spec.rb
+++ b/spec/features/units/show_spec.rb
@@ -22,6 +22,13 @@ RSpec.feature "Unit page", type: :feature do
       expect(page).to have_css('h1', text: unit.name)
     end
 
+    specify "there should be breadcrumbs for the CCP and current unit" do
+      within('.govuk-breadcrumbs') do
+        expect(page).to have_link(ccp.name, href: complete_curriculum_programme_path(ccp))
+        expect(page).to have_content(unit.name)
+      end
+    end
+
     specify %(there should be a table containing this unit's lessons) do
       within('table.units > tbody') do
         expect(page).to have_css('tr.unit', count: number_of_lessons)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require "rspec/rails"
 require "support/factory_bot"
 require "support/api_examples"
 require "faker"
+require "action_view/component/test_helpers"
 
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -62,6 +63,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include ActionView::Component::TestHelpers, type: :component
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
Add an ActionView Component that implements breadcrumbs, along with some helpers to facilitate its use.

```slim
- breadcrumbs(crumbs: { 'level one' => '/level-one', 'level two' => '/level-two' }, current_page: 'level three')
```

Breadcrumbs have been added in the above manner to the CCP, Units and Lesson pages

![Screenshot from 2020-01-31 14-43-59](https://user-images.githubusercontent.com/128088/73548185-3f5ae400-4438-11ea-8371-fd9d8e0afb6d.png)

Fixes #26
