### PR TITLE
Add HTTP Authentication to the staging env

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,13 @@ Naming/MethodParameterName:
 Rails/FilePath:
   Enabled: false
 
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - staging
+    - production
+
 Style/StringLiterals:
   Enabled: false
 Style/TrailingCommaInArguments:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include HTTPAuth
+
   before_action :set_raven_context
 
 private

--- a/app/controllers/concerns/http_auth.rb
+++ b/app/controllers/concerns/http_auth.rb
@@ -1,0 +1,15 @@
+module HTTPAuth
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :http_authenticate
+  end
+
+  def http_authenticate
+    return true unless Rails.env.staging?
+
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV.fetch('HTTP_AUTH_USER') && password == ENV.fetch('HTTP_AUTH_PASSWORD')
+    end
+  end
+end

--- a/spec/features/http_auth/access_spec.rb
+++ b/spec/features/http_auth/access_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'HTTP Auth for the staging environment', type: :feature do
+  describe 'accessing the site' do
+    context 'when the environment is staging' do
+      before do
+        allow(Rails.env).to receive(:staging?).and_return(true)
+      end
+
+      context 'when no credentials are provided' do
+        before { visit('/') }
+
+        specify 'should return 401: unauthorized and prompt the user for credentials' do
+          expect(page).to have_http_status(:unauthorized)
+        end
+      end
+
+      context 'when credentials are provided' do
+        let(:username) { 'nelsonmuntz' }
+        let(:password) { 'ha-ha' }
+
+        before do
+          allow(ENV).to receive(:fetch).with('HTTP_AUTH_USER').and_return(username)
+          allow(ENV).to receive(:fetch).with('HTTP_AUTH_PASSWORD').and_return(password)
+        end
+
+        let(:credentials) do
+          ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
+        end
+
+        before do
+          page.driver.header 'Authorization', credentials
+        end
+
+        before { visit('/') }
+
+        specify 'should prompt for auth when requesting the landing page' do
+          expect(page).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context 'when the environment is not staging' do
+      before do
+        allow(Rails.env).to receive(:staging?).and_return(false)
+      end
+
+      before { visit('/') }
+
+      specify 'should allow access' do
+        expect(page).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The credentials need to be set by environment variables for user and password:

* `HTTP_AUTH_USER`
* `HTTP_AUTH_PASSWORD`

This is required as we're not meant to be serving GOV.UK themed assets unprotected from other domains just yet