### PR TITLE
Add media query to make cards full-width on mobile

### DIFF
--- a/app/webpacker/styles/_cards.scss
+++ b/app/webpacker/styles/_cards.scss
@@ -4,6 +4,10 @@
   grid-template-columns: 1fr 1fr 1fr;
   grid-gap: 1rem;
 
+  @include govuk-media-query($until: desktop) {
+    grid-template-columns: 1fr;
+  }
+
   .card {
     margin: 0.5rem 0;
     padding: 20px;


### PR DESCRIPTION
Add a CSS media query that changes the CCP layout from three to one columns when the screen is narrower than a desktop.

![output](https://user-images.githubusercontent.com/128088/73593581-a8f0f600-44fd-11ea-8e01-dee2f244f169.gif)
