### PR TITLE
Add create and update API actions

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,5 @@
+module Api
+  class BaseController < ApplicationController
+    protect_from_forgery with: :null_session
+  end
+end

--- a/app/controllers/api/v1/complete_curriculum_programmes_controller.rb
+++ b/app/controllers/api/v1/complete_curriculum_programmes_controller.rb
@@ -1,10 +1,10 @@
-class Api::V1::CompleteCurriculumProgrammesController < ApplicationController
+class Api::V1::CompleteCurriculumProgrammesController < Api::BaseController
   def index
-    @ccps = CompleteCurriculumProgramme.all
+    ccps = CompleteCurriculumProgramme.all
 
     render(
       json: SimpleAMS::Renderer::Collection.new(
-        @ccps,
+        ccps,
         serializer: CompleteCurriculumProgrammeSerializer,
         includes: []
       ).to_json
@@ -12,15 +12,33 @@ class Api::V1::CompleteCurriculumProgrammesController < ApplicationController
   end
 
   def show
-    @ccp = CompleteCurriculumProgramme
+    ccp = CompleteCurriculumProgramme
       .eager_load(:units)
       .find(params[:id])
 
-    render(
-      json: SimpleAMS::Renderer.new(
-        @ccp,
-        serializer: CompleteCurriculumProgrammeSerializer
-      ).to_json
+    render(json: serialize(ccp).to_json)
+  end
+
+  def create
+    ccp = CompleteCurriculumProgramme.new(ccp_params)
+
+    if ccp.save
+      render(json: serialize(ccp).to_json, status: :created)
+    else
+      render(json: { errors: ccp.errors.full_messages }, status: :bad_request)
+    end
+  end
+
+private
+
+  def ccp_params
+    params.require(:ccp).permit(:name, :overview, :benefits)
+  end
+
+  def serialize(ccp)
+    SimpleAMS::Renderer.new(
+      ccp,
+      serializer: CompleteCurriculumProgrammeSerializer
     )
   end
 end

--- a/app/controllers/api/v1/complete_curriculum_programmes_controller.rb
+++ b/app/controllers/api/v1/complete_curriculum_programmes_controller.rb
@@ -29,6 +29,16 @@ class Api::V1::CompleteCurriculumProgrammesController < Api::BaseController
     end
   end
 
+  def update
+    ccp = CompleteCurriculumProgramme.find(params[:id])
+
+    if ccp.update(ccp_params)
+      render(json: serialize(ccp).to_json, status: :ok)
+    else
+      render(json: { errors: ccp.errors.full_messages }, status: :bad_request)
+    end
+  end
+
 private
 
   def ccp_params

--- a/app/controllers/api/v1/lessons_controller.rb
+++ b/app/controllers/api/v1/lessons_controller.rb
@@ -1,12 +1,12 @@
 class Api::V1::LessonsController < ApplicationController
   def index
-    @lessons = Lesson
+    lessons = Lesson
       .where(unit_id: params[:unit_id])
       .all
 
     render(
       json: SimpleAMS::Renderer::Collection.new(
-        @lessons,
+        lessons,
         serializer: LessonSerializer,
         included: []
       ).to_json
@@ -14,16 +14,53 @@ class Api::V1::LessonsController < ApplicationController
   end
 
   def show
-    @lesson = Lesson
+    lesson = Lesson
       .eager_load(:unit)
       .where(unit_id: params[:unit_id])
       .find(params[:id])
 
-    render(
-      json: SimpleAMS::Renderer.new(
-        @lesson,
-        serializer: LessonSerializer
-      ).to_json
+    render(json: serialize(lesson).to_json)
+  end
+
+  def create
+    unit = Unit.find_by!(complete_curriculum_programme_id: params[:ccp_id], id: params[:unit_id])
+    lesson = unit.lessons.new(lesson_params)
+
+    if lesson.save
+      render(json: serialize(lesson).to_json, status: :created)
+    else
+      render(json: { errors: lesson.errors.full_messages }, status: :bad_request)
+    end
+  end
+
+  def update
+    lesson = Lesson.find_by!(unit_id: params[:unit_id], id: params[:id])
+
+    if lesson.update(lesson_params)
+      render(json: serialize(lesson).to_json, status: :ok)
+    else
+      render(json: { errors: lesson.errors.full_messages }, status: :bad_request)
+    end
+  end
+
+private
+
+  def lesson_params
+    params.require(:lesson).permit(
+      :name,
+      :summary,
+      :position,
+      :core_knowledge,
+      :previous_knowledge,
+      vocabulary: [],
+      misconceptions: []
+    )
+  end
+
+  def serialize(lesson)
+    SimpleAMS::Renderer.new(
+      lesson,
+      serializer: LessonSerializer
     )
   end
 end

--- a/app/controllers/api/v1/lessons_controller.rb
+++ b/app/controllers/api/v1/lessons_controller.rb
@@ -14,7 +14,10 @@ class Api::V1::LessonsController < ApplicationController
   end
 
   def show
-    @lesson = Lesson.find(params[:id])
+    @lesson = Lesson
+      .eager_load(:unit)
+      .where(unit_id: params[:unit_id])
+      .find(params[:id])
 
     render(
       json: SimpleAMS::Renderer.new(

--- a/app/controllers/api/v1/units_controller.rb
+++ b/app/controllers/api/v1/units_controller.rb
@@ -1,12 +1,12 @@
 class Api::V1::UnitsController < ApplicationController
   def index
-    @units = Unit
+    units = Unit
       .where(complete_curriculum_programme_id: params[:ccp_id])
       .all
 
     render(
       json: SimpleAMS::Renderer::Collection.new(
-        @units,
+        units,
         serializer: UnitSerializer,
         includes: []
       ).to_json
@@ -14,15 +14,44 @@ class Api::V1::UnitsController < ApplicationController
   end
 
   def show
-    @unit = Unit
+    unit = Unit
       .where(complete_curriculum_programme_id: params[:ccp_id])
       .find(params[:id])
 
-    render(
-      json: SimpleAMS::Renderer.new(
-        @unit,
-        serializer: UnitSerializer
-      ).to_json
+    render(json: serialize(unit).to_json)
+  end
+
+  def create
+    ccp = CompleteCurriculumProgramme.find(params[:ccp_id])
+    unit = ccp.units.new(unit_params)
+
+    if unit.save
+      render(json: serialize(unit).to_json, status: :created)
+    else
+      render(json: { errors: unit.errors.full_messages }, status: :bad_request)
+    end
+  end
+
+  def update
+    unit = Unit.find_by!(id: params[:id], complete_curriculum_programme_id: params[:ccp_id])
+
+    if unit.update(unit_params)
+      render(json: serialize(unit).to_json, status: :ok)
+    else
+      render(json: { errors: unit.errors.full_messages }, status: :bad_request)
+    end
+  end
+
+private
+
+  def unit_params
+    params.require(:unit).permit(:name, :overview, :benefits)
+  end
+
+  def serialize(unit)
+    SimpleAMS::Renderer.new(
+      unit,
+      serializer: UnitSerializer
     )
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :ccps, controller: 'complete_curriculum_programmes', only: %i(index show create) do
+      resources :ccps, controller: 'complete_curriculum_programmes', only: %i(index show create update) do
         resources :units, only: %i(index show) do
           resources :lessons, only: %i(index show) do
             resources :lesson_parts, only: %i(index show)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :ccps, controller: 'complete_curriculum_programmes', only: %i(index show) do
+      resources :ccps, controller: 'complete_curriculum_programmes', only: %i(index show create) do
         resources :units, only: %i(index show) do
           resources :lessons, only: %i(index show) do
             resources :lesson_parts, only: %i(index show)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :ccps, controller: 'complete_curriculum_programmes', only: %i(index show create update) do
-        resources :units, only: %i(index show) do
-          resources :lessons, only: %i(index show) do
+        resources :units, only: %i(index show create update) do
+          resources :lessons, only: %i(index show create update) do
             resources :lesson_parts, only: %i(index show)
           end
         end

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -18,9 +18,9 @@
             "examples": {
               "application/json": [
                 {
-                  "name": "Western Jenkins Academy",
-                  "overview": "Nostrum quia enim. Ipsum officiis qui. Id et harum.",
-                  "benefits": "In est aut. Dolor sed magnam. Dicta illum expedita.\n\nEveniet blanditiis nihil. Delectus aut aut. Sint est quae.\n\nEt consequatur similique. Repudiandae sequi sed. Rerum qui voluptas.",
+                  "name": "West Kunde Academy",
+                  "overview": "Aut tempore rerum. Rem repudiandae accusamus. Consectetur laborum omnis.",
+                  "benefits": "Cupiditate in praesentium. Nihil est reprehenderit. Eos et eveniet.\n\nEveniet aut dolores. Quaerat atque debitis. Est autem eligendi.\n\nUnde nihil sit. Occaecati voluptatem assumenda. Consectetur aut eos.",
                   "id": 1
                 }
               ]
@@ -66,9 +66,9 @@
             "examples": {
               "application/json": {
                 "ccp": {
-                  "name": "Rogahn College",
-                  "overview": "Nisi recusandae voluptas. In quo aut. Nihil molestiae maxime.",
-                  "benefits": "Repellat natus iure. Sequi ut et. Dolorem sed vel.\n\nEa illo sed. Omnis aut sunt. Necessitatibus quos est.\n\nNam sit harum. Similique voluptas numquam. Reprehenderit nam occaecati.",
+                  "name": "West Minnesota Academy",
+                  "overview": "Consequatur id in. Blanditiis aspernatur est. Est et dolores.",
+                  "benefits": "Ut sequi sint. Nobis accusamus a. Quis sunt facere.\n\nEt veniam quaerat. Delectus laudantium quaerat. Molestiae atque voluptatem.\n\nDolore ipsam cumque. Aliquam quam corporis. Ab saepe cumque.",
                   "id": 1
                 }
               }
@@ -82,7 +82,7 @@
     },
     "/ccps/{id}": {
       "get": {
-        "summary": "retrieves one complete curriculum programme (CCP)",
+        "summary": "retrieves one complete curriculum programme",
         "tags": [
           "CCP"
         ],
@@ -101,21 +101,21 @@
             "description": "ccp found",
             "examples": {
               "application/json": {
-                "name": "East Gerlach Institute",
-                "overview": "Velit ex qui. Sunt dolorem inventore. Beatae sint fugiat.",
-                "benefits": "Error vel sed. Et consequatur aliquid. Vel minima ipsam.\n\nBeatae consequatur sint. Qui qui non. Molestias similique sit.\n\nEt placeat amet. Dolore deserunt et. Illum facere laborum.",
+                "name": "Southern North Dakota Academy",
+                "overview": "Illum voluptatem aut. Non veniam eveniet. Molestiae et ipsum.",
+                "benefits": "Necessitatibus fuga similique. Non minima sunt. Nam labore occaecati.\n\nVero sit ullam. Ab qui a. Quia sit inventore.\n\nExercitationem magni placeat. Consectetur repellendus dolores. Saepe explicabo dolorum.",
                 "id": 1,
                 "units": [
                   {
-                    "name": "Esse",
-                    "overview": "Modi est velit. Ea consectetur laudantium. Laborum consequatur perferendis.",
-                    "benefits": "Est quisquam autem. Voluptatum totam sit. Quisquam vel dolorem.\n\nVoluptatem et ut. Id aliquid similique. Natus eligendi ducimus.\n\nIure neque temporibus. Vel quos mollitia. Sint earum sit.",
+                    "name": "Dolore",
+                    "overview": "Magni ratione voluptatem. Mollitia exercitationem at. Consequuntur voluptatum quisquam.",
+                    "benefits": "Incidunt et sit. Quis dolorem iste. Accusamus rerum numquam.\n\nEt quo itaque. Dolor ut nam. Et assumenda unde.\n\nNihil voluptatem accusamus. Fuga inventore illo. Omnis quisquam similique.",
                     "id": 1
                   },
                   {
-                    "name": "Dolorum",
-                    "overview": "Delectus praesentium cumque. Aut beatae dolore. Eum quas excepturi.",
-                    "benefits": "Accusantium et ad. Quam aspernatur est. Rerum ducimus unde.\n\nQuas impedit consequatur. Unde eos dolores. Voluptates ratione qui.\n\nEt assumenda voluptatem. Inventore velit consequatur. Excepturi ut accusamus.",
+                    "name": "Qui",
+                    "overview": "Quaerat itaque blanditiis. Aut fugit quasi. Veniam alias quia.",
+                    "benefits": "Debitis in facilis. Quo aut et. Animi molestiae pariatur.\n\nConsequatur est consequuntur. Vel voluptas sit. Ipsa quisquam voluptas.\n\nEt nihil doloribus. Facilis omnis quo. Omnis reiciendis impedit.",
                     "id": 2
                   }
                 ]
@@ -164,6 +164,40 @@
             }
           }
         }
+      },
+      "patch": {
+        "summary": "update the referenced complete curriculum programme",
+        "tags": [
+          "CCP"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ccp updated",
+            "examples": {
+              "application/json": {
+                "ccp": {
+                  "name": "North Ankunding",
+                  "overview": "Magnam enim perspiciatis. Labore rerum quis. Culpa deleniti qui.",
+                  "benefits": "Et sit et. Asperiores sapiente molestias. Reiciendis enim minima.\n\nArchitecto corporis animi. Doloribus quasi deserunt. Recusandae aut dicta.\n\nDolor quo aliquam. Sit aut iusto. Aspernatur quis culpa.",
+                  "id": 1
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid ccp"
+          }
+        }
       }
     },
     "/ccps/{ccp_id}/units/{unit_id}/lessons": {
@@ -197,36 +231,36 @@
               "application/json": [
                 [
                   {
-                    "name": "Alexander Fleming",
+                    "name": "Comte de Buffon",
                     "summary": "Lesson 1",
-                    "core_knowledge": "Nemo commodi fugiat. Unde aut voluptatem. Sit quia illo.\n\nSaepe rem magni. Dolorem harum nesciunt. Sed impedit rem.\n\nVero vel molestias. Est suscipit est. Ut officiis quia.",
-                    "previous_knowledge": "Eius et eveniet. Ea ipsam nobis. Voluptas inventore sit.\n\nRepellat sed ipsam. Odit quidem ea. Beatae distinctio sed.\n\nAtque iusto repudiandae. Assumenda sint repudiandae. Minima consequatur commodi.",
+                    "core_knowledge": "Adipisci a repellendus. Iusto recusandae ut. Ab soluta a.\n\nEt molestiae enim. Minus sequi quia. Cum asperiores blanditiis.\n\nQuos recusandae tempora. Quam provident a. Molestiae voluptates consectetur.",
+                    "previous_knowledge": "Tenetur id reiciendis. Beatae laborum dicta. Veritatis dolor ducimus.\n\nVitae quae aut. Quae illo qui. Tenetur sint dolor.\n\nMollitia provident qui. Recusandae explicabo voluptatem. Quidem omnis totam.",
                     "vocabulary": [
-                      "Explicabo expedita voluptatem. Est facilis dolores. Corporis iusto nam.",
-                      "Architecto inventore aut. Quaerat inventore mollitia. Id omnis quia.",
-                      "Cum quis sapiente. Aut soluta numquam. Voluptatem nam nisi."
+                      "Sit repudiandae ut. Iste unde tempora. Ut praesentium maiores.",
+                      "Voluptatem dignissimos et. Est accusamus iusto. Voluptatum perspiciatis incidunt.",
+                      "Doloremque voluptatibus voluptates. Accusantium iusto earum. Omnis laboriosam qui."
                     ],
                     "misconceptions": [
-                      "Voluptas maiores inventore. Tempore est veritatis. Ab nemo et.",
-                      "Voluptatem aliquam voluptatem. Sit perferendis ipsam. Adipisci aut autem.",
-                      "Quo voluptate eum. In consequatur praesentium. Eius est tempora."
+                      "Quia tempore non. Vero labore quia. Dolore quo quisquam.",
+                      "Deleniti et nulla. Quo amet reiciendis. Iste quod rerum.",
+                      "Eligendi sint quibusdam. Molestiae assumenda alias. Provident dicta debitis."
                     ],
                     "id": 1
                   },
                   {
-                    "name": "Franz Boas",
+                    "name": "Linus Pauling",
                     "summary": "Lesson 2",
-                    "core_knowledge": "Quia cum aut. Repellat dolor laborum. Provident et tempora.\n\nSit odio tempore. Minima nesciunt est. Nemo dolorem voluptate.\n\nArchitecto necessitatibus facilis. Similique libero architecto. Alias nemo ullam.",
-                    "previous_knowledge": "Assumenda qui eveniet. Voluptatem nihil delectus. Ut autem sed.\n\nAutem velit atque. Praesentium et voluptatem. Praesentium qui explicabo.\n\nQuos ut praesentium. Eius qui sed. Repellat molestias dolor.",
+                    "core_knowledge": "Ipsam consectetur ex. Qui architecto ut. Aut aut voluptatum.\n\nOptio inventore ex. Est placeat provident. Corporis sit quo.\n\nEt eos possimus. Quia quidem ipsum. Voluptatem molestias dolorem.",
+                    "previous_knowledge": "At voluptatum est. Qui sunt voluptatum. Qui nobis alias.\n\nProvident nulla et. Repellendus fugiat est. Unde repellat doloribus.\n\nQuis vel et. Animi est aliquam. Quod fugiat ut.",
                     "vocabulary": [
-                      "Debitis recusandae inventore. Repudiandae asperiores pariatur. Qui et omnis.",
-                      "Non enim quia. Odit eligendi necessitatibus. Aut cum ducimus.",
-                      "Sed dolorem dolores. Necessitatibus ea eligendi. Odit distinctio minus."
+                      "Aut ducimus praesentium. Cumque eligendi ut. Qui adipisci quo.",
+                      "Debitis ex voluptas. Veritatis similique voluptas. Ducimus non magnam.",
+                      "Et ea qui. Sequi laboriosam illo. Ut id aut."
                     ],
                     "misconceptions": [
-                      "Eos sunt tempore. Sed debitis molestiae. Voluptate eligendi sunt.",
-                      "Qui aut officia. Ratione voluptatem sit. Ex quia et.",
-                      "Tenetur velit tempora. Sed sit a. Qui expedita quia."
+                      "Reprehenderit pariatur aut. Iure sapiente consequuntur. Maxime facere molestias.",
+                      "Ea est repellat. Id consectetur possimus. Corporis ullam porro.",
+                      "Soluta eos occaecati. Rerum voluptatem quidem. Numquam dolor rem."
                     ],
                     "id": 2
                   }
@@ -313,19 +347,19 @@
             "description": "lesson found",
             "examples": {
               "application/json": {
-                "name": "Dmitri Mendeleev",
+                "name": "Enrico Fermi",
                 "summary": "Lesson 3",
-                "core_knowledge": "Voluptates quia iure. Aliquam alias aut. Nihil ea et.\n\nMolestiae vitae ullam. Molestias debitis ducimus. Temporibus asperiores quia.\n\nSapiente quia atque. Rerum corporis accusamus. Soluta quos distinctio.",
-                "previous_knowledge": "Sed non velit. Est earum autem. Rerum omnis et.\n\nQuam ea autem. Dignissimos enim eum. Autem accusantium eligendi.\n\nSaepe ipsa ullam. Dolorem debitis ad. Dolorem deleniti aliquid.",
+                "core_knowledge": "Dolores veniam quibusdam. Aperiam qui quia. Eum hic eum.\n\nQuaerat ea perferendis. Numquam velit molestiae. Ut dignissimos quidem.\n\nNon autem fuga. Vitae magni saepe. Quaerat debitis voluptatem.",
+                "previous_knowledge": "Quae beatae placeat. Quo minima ratione. Molestiae vel officiis.\n\nError qui ut. Est magni voluptatem. Eveniet molestiae voluptates.\n\nSapiente saepe et. Porro dolorum et. Et est dolore.",
                 "vocabulary": [
-                  "Ut tempora blanditiis. Culpa fugiat est. Qui nihil omnis.",
-                  "Aut cupiditate qui. Debitis itaque autem. Explicabo repudiandae ut.",
-                  "Natus aliquid quam. Animi minus explicabo. Aut repudiandae iste."
+                  "Non deserunt voluptas. Delectus minus sapiente. Et quaerat error.",
+                  "Facere delectus aut. At eveniet in. Sit quis et.",
+                  "Et iste consequuntur. Consequuntur rerum aut. Neque quaerat autem."
                 ],
                 "misconceptions": [
-                  "Rerum at voluptatem. Explicabo error voluptatem. Quasi nemo veniam.",
-                  "Debitis consequatur ducimus. Rem non voluptatem. Numquam unde culpa.",
-                  "Accusantium et in. Nisi quasi eveniet. Et ea nesciunt."
+                  "Cumque dolores at. Voluptas ex dignissimos. Sint fuga repudiandae.",
+                  "Laudantium optio natus. Nostrum et debitis. Quibusdam rerum quo.",
+                  "Saepe voluptatem omnis. Accusantium sit modi. At iste modi."
                 ],
                 "id": 1
               }
@@ -393,15 +427,15 @@
               "application/json": [
                 [
                   {
-                    "name": "Aut",
-                    "overview": "Est blanditiis autem. Natus sint totam. Repudiandae placeat quia.",
-                    "benefits": "Nobis aliquid velit. Non rerum at. Reiciendis a itaque.\n\nExercitationem est soluta. Ex quam cumque. Consequatur numquam et.\n\nExcepturi corrupti repellat. Ut aut reprehenderit. Nostrum magni asperiores.",
+                    "name": "Fugit",
+                    "overview": "Provident officia minima. Qui dolor excepturi. Aperiam omnis est.",
+                    "benefits": "Sunt est aut. Magnam ullam autem. Unde sed iure.\n\nIllum perspiciatis quo. Voluptatem necessitatibus qui. Sit qui placeat.\n\nDolorem aperiam perferendis. Sint temporibus ut. Magni adipisci ducimus.",
                     "id": 1
                   },
                   {
-                    "name": "Aut",
-                    "overview": "Corporis blanditiis ut. Velit hic ipsum. Fugit sit omnis.",
-                    "benefits": "Totam molestias deleniti. Et eaque rerum. Molestiae excepturi a.\n\nEst incidunt corporis. Iure et dolor. Incidunt voluptatem quis.\n\nPraesentium accusamus ipsa. Officiis similique est. Molestiae minima delectus.",
+                    "name": "Pariatur",
+                    "overview": "Ut ipsum ex. Maiores veniam dolores. Facere aut suscipit.",
+                    "benefits": "Molestias ipsum iure. Perspiciatis a excepturi. Quidem harum assumenda.\n\nQuae alias cum. Rerum perspiciatis dolorem. Voluptate nesciunt libero.\n\nSed voluptatem provident. A qui qui. Eius veniam enim.",
                     "id": 2
                   }
                 ]
@@ -464,65 +498,65 @@
             "description": "unit found",
             "examples": {
               "application/json": {
-                "name": "Nihil",
-                "overview": "Suscipit numquam ea. Eius voluptas et. Dolores dolorem vel.",
-                "benefits": "Assumenda libero numquam. Saepe minus unde. Provident non et.\n\nLaudantium ut est. Laborum hic qui. Facilis nulla et.\n\nDeserunt aliquam consequuntur. Officia non accusantium. Qui animi sed.",
+                "name": "Dolorem",
+                "overview": "Tempora culpa modi. Occaecati excepturi vel. Voluptate eius qui.",
+                "benefits": "Dignissimos similique ea. Voluptatem alias modi. Voluptatum tempora rerum.\n\nVelit molestiae et. Laudantium veniam est. Assumenda magnam perspiciatis.\n\nBeatae aperiam ratione. Tempora inventore modi. Quam exercitationem ea.",
                 "id": 1,
                 "complete_curriculum_programme": {
-                  "name": "Northern Wisconsin University",
-                  "overview": "Quis illo fugiat. Ut explicabo totam. Eligendi ipsa incidunt.",
-                  "benefits": "Et ipsa distinctio. Error optio excepturi. Quia quidem hic.\n\nEt sed minima. Accusamus expedita eos. Aperiam omnis corporis.\n\nMaiores eius error. Nemo quam culpa. Et velit qui.",
+                  "name": "East Georgia College",
+                  "overview": "Exercitationem libero et. Ut enim itaque. Itaque totam excepturi.",
+                  "benefits": "Consequatur soluta natus. Nulla omnis ea. Perferendis velit ut.\n\nOmnis quisquam inventore. Et a sequi. Sapiente perspiciatis excepturi.\n\nDeleniti accusantium voluptatem. Ea dolore minima. Et et officiis.",
                   "id": 1
                 },
                 "lessons": [
                   {
-                    "name": "Ernst Haeckel",
+                    "name": "Archimedes",
                     "summary": "Lesson 4",
-                    "core_knowledge": "Et nemo soluta. Ratione iure omnis. Qui soluta vero.\n\nVero odit dolore. Quos minus quis. Eum et mollitia.\n\nSapiente temporibus distinctio. Laudantium quis itaque. In ipsa voluptatum.",
-                    "previous_knowledge": "Saepe excepturi quidem. Possimus earum consequuntur. Qui officia quis.\n\nEaque officiis eveniet. Omnis omnis dolorem. Sed et eius.\n\nUnde quos aut. Molestiae vel voluptatem. Dolor dicta perspiciatis.",
+                    "core_knowledge": "Id rerum non. Voluptatibus non quo. Quis neque ut.\n\nQuia molestiae id. Qui sunt ea. Sequi dolores placeat.\n\nExpedita nesciunt sed. Dicta incidunt deleniti. Voluptatem ducimus cupiditate.",
+                    "previous_knowledge": "Pariatur voluptas maxime. Maxime non nemo. Fugiat alias rerum.\n\nNihil eos recusandae. Consequuntur inventore corporis. Minus temporibus et.\n\nAb vitae aspernatur. Repellat rerum ut. Ab possimus voluptatem.",
                     "vocabulary": [
-                      "Soluta animi adipisci. Animi dolor tempora. Eveniet accusamus quis.",
-                      "Consequatur in facilis. Maxime laborum est. Voluptatum facere recusandae.",
-                      "Quas perspiciatis amet. In similique nam. Est sint eligendi."
+                      "Quaerat enim repellat. Itaque voluptatum qui. Corrupti quisquam non.",
+                      "Aut eos molestias. Quam qui ut. Ut quia dignissimos.",
+                      "Velit vitae voluptatem. Est ducimus quasi. Repellat et officiis."
                     ],
                     "misconceptions": [
-                      "Sunt saepe et. Aut et eaque. Illum architecto blanditiis.",
-                      "Ut est eos. Aut laboriosam assumenda. Quaerat non id.",
-                      "Sed molestias voluptatem. Fugiat sint dolores. Quis optio totam."
+                      "Odit eaque fuga. Omnis distinctio provident. Illo rerum nam.",
+                      "Neque quia officiis. Magni dolorem tempora. Ut dolores et.",
+                      "Tempore unde et. Et aut saepe. Quod debitis in."
                     ],
                     "id": 1
                   },
                   {
-                    "name": "Trofim Lysenko",
+                    "name": "John von Neumann",
                     "summary": "Lesson 5",
-                    "core_knowledge": "Soluta necessitatibus debitis. Nesciunt qui atque. Tempora pariatur cupiditate.\n\nDolor ex autem. Distinctio quis fugit. Quibusdam sunt accusamus.\n\nEa provident ex. Facere ipsum vel. Iure asperiores autem.",
-                    "previous_knowledge": "Nesciunt tenetur sunt. Excepturi non qui. Quo non sit.\n\nQuia non nisi. Libero tenetur dolores. Possimus ea aut.\n\nEt non aut. Et rerum expedita. Modi nisi in.",
+                    "core_knowledge": "Mollitia vel voluptate. Fuga unde eos. Est inventore nostrum.\n\nProvident aut est. Nam doloremque perspiciatis. Est ex quisquam.\n\nQuaerat ea maxime. Ab magnam sit. Voluptatem modi est.",
+                    "previous_knowledge": "Molestiae eligendi ab. Voluptatibus nisi tenetur. Cupiditate aut nisi.\n\nInventore quia et. Enim rerum ratione. Dolores sed suscipit.\n\nCum autem praesentium. Corrupti quis magni. Non repudiandae non.",
                     "vocabulary": [
-                      "Eaque impedit qui. Fugiat sapiente aut. Et qui accusantium.",
-                      "Vel non qui. Rerum voluptatum officia. Qui nemo ut.",
-                      "Exercitationem praesentium dolores. Voluptatibus totam ex. Aut animi sit."
+                      "Aut eum nobis. Ab velit quia. Unde adipisci corrupti.",
+                      "Est in impedit. Dolorem dicta maiores. Reprehenderit nihil ut.",
+                      "Iusto dolorum sit. Ipsum sit aut. Facere voluptas ullam."
                     ],
                     "misconceptions": [
-                      "Officiis illum et. Itaque atque sed. Qui recusandae laborum.",
-                      "Tempora ex enim. Incidunt quia eius. Rerum pariatur quibusdam.",
-                      "Ipsa laudantium iusto. Delectus cumque cupiditate. Ipsum rem officia."
+                      "Hic rerum praesentium. Rerum temporibus aut. Est est quo.",
+                      "Labore minus eum. Modi asperiores possimus. Temporibus qui eos.",
+                      "Officiis aspernatur aperiam. Ea dolor autem. Omnis in quis."
                     ],
                     "id": 2
                   },
                   {
-                    "name": "B. F. Skinner",
+                    "name": "Arthur Eddington",
                     "summary": "Lesson 6",
-                    "core_knowledge": "Vel dolorum et. Rerum voluptas porro. Eos corporis saepe.\n\nQuia sed velit. Distinctio corporis qui. Deleniti ea nemo.\n\nDicta sunt culpa. Voluptatibus voluptate consectetur. Architecto voluptatem repellat.",
-                    "previous_knowledge": "A sapiente esse. Inventore accusamus expedita. Quo at repellendus.\n\nMolestias ipsam et. Fuga quia ipsam. Voluptate iusto quo.\n\nAt qui voluptatem. Enim iusto totam. Ipsam mollitia hic.",
+                    "core_knowledge": "Accusantium voluptatem rerum. Voluptatem quas est. Assumenda ad aperiam.\n\nLaborum amet sunt. Corporis in impedit. Harum eum vel.\n\nQuasi nisi exercitationem. Facilis quos esse. Ullam aut saepe.",
+                    "previous_knowledge": "Aliquid eum nihil. Et ut sint. Laboriosam mollitia beatae.\n\nQuos ullam deserunt. Maiores laborum laboriosam. Libero sunt eum.\n\nLibero molestiae sit. Adipisci libero similique. Cum aut a.",
                     "vocabulary": [
-                      "Dolorem repudiandae placeat. Temporibus et accusantium. Autem commodi quas.",
-                      "Sit amet et. Quas nesciunt est. Eveniet exercitationem dolor.",
-                      "Eveniet fugit veritatis. Laboriosam pariatur tenetur. Omnis voluptatem et."
+                      "Laborum voluptas est. Inventore laudantium voluptas. Aut et rem.",
+                      "Eveniet qui est. Laudantium odit maxime. Sit nulla cumque.",
+                      "Aliquid commodi porro. Dolorem dolores error. Dolorem maiores autem."
                     ],
                     "misconceptions": [
-                      "Voluptatem nobis maxime. Ut illo repellendus. Aut repudiandae fugiat.",
-                      "Pariatur deleniti vero. Ea architecto et. Aperiam quasi qui.",
-                      "Hic laborum est. Non dolores omnis. Nobis non ipsa."
+                      "Aperiam doloribus exercitationem. Ipsam quos est. Qui qui nihil.",
+                      "Nisi enim et. Beatae minus quos. Minima qui aut.",
+                      "Provident exercitationem iste. Ea vero ut. Totam suscipit repudiandae."
                     ],
                     "id": 3
                   }

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -60,6 +60,39 @@
         "parameters": [
 
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ccp": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "benefits": {
+                        "type": "string"
+                      },
+                      "overview": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "benefits",
+                      "overview"
+                    ]
+                  },
+                  "required": [
+                    "ccp"
+                  ]
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "201": {
             "description": "ccp created",
@@ -179,6 +212,39 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "ccp": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "benefits": {
+                        "type": "string"
+                      },
+                      "overview": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "benefits",
+                      "overview"
+                    ]
+                  },
+                  "required": [
+                    "ccp"
+                  ]
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "ccp updated",
@@ -326,6 +392,52 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "lesson": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "summary": {
+                        "type": "string"
+                      },
+                      "core_knowledge": {
+                        "type": "string"
+                      },
+                      "previous_knowledge": {
+                        "type": "string"
+                      },
+                      "vocabulary": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "misconceptions": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "lesson"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "201": {
             "description": "lesson created",
@@ -386,6 +498,52 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "lesson": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "summary": {
+                        "type": "string"
+                      },
+                      "core_knowledge": {
+                        "type": "string"
+                      },
+                      "previous_knowledge": {
+                        "type": "string"
+                      },
+                      "vocabulary": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "misconceptions": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "unit"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "lesson found",
@@ -476,6 +634,52 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "lesson": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "summary": {
+                        "type": "string"
+                      },
+                      "core_knowledge": {
+                        "type": "string"
+                      },
+                      "previous_knowledge": {
+                        "type": "string"
+                      },
+                      "vocabulary": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "misconceptions": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "lesson"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "lesson updated",
@@ -583,6 +787,39 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "unit": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "benefits": {
+                        "type": "string"
+                      },
+                      "overview": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "benefits",
+                      "overview"
+                    ]
+                  },
+                  "required": [
+                    "unit"
+                  ]
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "201": {
             "description": "unit created",
@@ -790,6 +1027,39 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "unit": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "benefits": {
+                        "type": "string"
+                      },
+                      "overview": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "benefits",
+                      "overview"
+                    ]
+                  },
+                  "required": [
+                    "unit"
+                  ]
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "unit updated",

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -8,7 +8,7 @@
   "paths": {
     "/ccps": {
       "get": {
-        "summary": "retrieves all complete curriculum programmes (CCPs)",
+        "summary": "retrieves all complete curriculum programmes",
         "tags": [
           "CCP"
         ],
@@ -18,9 +18,9 @@
             "examples": {
               "application/json": [
                 {
-                  "name": "Block University",
-                  "overview": "Dolores quo cum. Magni eveniet earum. In eum voluptatem.",
-                  "benefits": "Rem corporis repudiandae. Qui sint earum. Explicabo qui natus.\n\nVoluptatem dicta fugiat. Ut ducimus unde. Libero dolor distinctio.\n\nEt velit explicabo. Voluptates nesciunt in. Delectus eaque molestiae.",
+                  "name": "Western Jenkins Academy",
+                  "overview": "Nostrum quia enim. Ipsum officiis qui. Id et harum.",
+                  "benefits": "In est aut. Dolor sed magnam. Dicta illum expedita.\n\nEveniet blanditiis nihil. Delectus aut aut. Sint est quae.\n\nEt consequatur similique. Repudiandae sequi sed. Rerum qui voluptas.",
                   "id": 1
                 }
               ]
@@ -51,6 +51,33 @@
             }
           }
         }
+      },
+      "post": {
+        "summary": "creates a new complete curriculum programme",
+        "tags": [
+          "CCP"
+        ],
+        "parameters": [
+
+        ],
+        "responses": {
+          "201": {
+            "description": "ccp created",
+            "examples": {
+              "application/json": {
+                "ccp": {
+                  "name": "Rogahn College",
+                  "overview": "Nisi recusandae voluptas. In quo aut. Nihil molestiae maxime.",
+                  "benefits": "Repellat natus iure. Sequi ut et. Dolorem sed vel.\n\nEa illo sed. Omnis aut sunt. Necessitatibus quos est.\n\nNam sit harum. Similique voluptas numquam. Reprehenderit nam occaecati.",
+                  "id": 1
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid ccp"
+          }
+        }
       }
     },
     "/ccps/{id}": {
@@ -74,21 +101,21 @@
             "description": "ccp found",
             "examples": {
               "application/json": {
-                "name": "Anderson University",
-                "overview": "Accusamus maxime hic. Fuga placeat est. Assumenda culpa atque.",
-                "benefits": "Aperiam nesciunt iure. Adipisci qui voluptatibus. Omnis et alias.\n\nVoluptatibus placeat illum. Libero dolorem cupiditate. Natus voluptas optio.\n\nQui omnis consequuntur. Voluptatum qui voluptatem. Maxime magnam consequuntur.",
+                "name": "East Gerlach Institute",
+                "overview": "Velit ex qui. Sunt dolorem inventore. Beatae sint fugiat.",
+                "benefits": "Error vel sed. Et consequatur aliquid. Vel minima ipsam.\n\nBeatae consequatur sint. Qui qui non. Molestias similique sit.\n\nEt placeat amet. Dolore deserunt et. Illum facere laborum.",
                 "id": 1,
                 "units": [
                   {
-                    "name": "Aut",
-                    "overview": "Assumenda sit quod. Ut ut quidem. Consequuntur exercitationem excepturi.",
-                    "benefits": "Aut beatae numquam. Soluta dolores hic. Enim tenetur expedita.\n\nRerum et ex. Facilis sapiente ullam. Reprehenderit tempore molestiae.\n\nDoloremque et et. Suscipit accusantium velit. Ea maiores placeat.",
+                    "name": "Esse",
+                    "overview": "Modi est velit. Ea consectetur laudantium. Laborum consequatur perferendis.",
+                    "benefits": "Est quisquam autem. Voluptatum totam sit. Quisquam vel dolorem.\n\nVoluptatem et ut. Id aliquid similique. Natus eligendi ducimus.\n\nIure neque temporibus. Vel quos mollitia. Sint earum sit.",
                     "id": 1
                   },
                   {
-                    "name": "Rerum",
-                    "overview": "Fugiat minima voluptatem. Velit temporibus similique. Ad eos quia.",
-                    "benefits": "Autem et nostrum. Cum rem quae. Officiis necessitatibus sequi.\n\nOdit sit ratione. Aut aliquam est. Ullam autem sed.\n\nMolestiae voluptatem tempore. Fugit tempora non. Labore est similique.",
+                    "name": "Dolorum",
+                    "overview": "Delectus praesentium cumque. Aut beatae dolore. Eum quas excepturi.",
+                    "benefits": "Accusantium et ad. Quam aspernatur est. Rerum ducimus unde.\n\nQuas impedit consequatur. Unde eos dolores. Voluptates ratione qui.\n\nEt assumenda voluptatem. Inventore velit consequatur. Excepturi ut accusamus.",
                     "id": 2
                   }
                 ]
@@ -170,36 +197,36 @@
               "application/json": [
                 [
                   {
-                    "name": "Edward Teller",
+                    "name": "Alexander Fleming",
                     "summary": "Lesson 1",
-                    "core_knowledge": "Perferendis voluptatibus quia. Enim enim ipsam. Ratione dolorem et.\n\nQuas adipisci reiciendis. Quia iure vel. Quia similique ipsum.\n\nEt ad voluptas. Velit sed amet. Sint incidunt odio.",
-                    "previous_knowledge": "Quia eaque eos. Est et id. Beatae consequatur facilis.\n\nRatione qui officiis. Vel aliquam ut. Tempora temporibus esse.\n\nSed nihil ut. Ullam aperiam magni. Sint asperiores praesentium.",
+                    "core_knowledge": "Nemo commodi fugiat. Unde aut voluptatem. Sit quia illo.\n\nSaepe rem magni. Dolorem harum nesciunt. Sed impedit rem.\n\nVero vel molestias. Est suscipit est. Ut officiis quia.",
+                    "previous_knowledge": "Eius et eveniet. Ea ipsam nobis. Voluptas inventore sit.\n\nRepellat sed ipsam. Odit quidem ea. Beatae distinctio sed.\n\nAtque iusto repudiandae. Assumenda sint repudiandae. Minima consequatur commodi.",
                     "vocabulary": [
-                      "Voluptate totam maxime. Quisquam natus quae. Aut iure ut.",
-                      "Praesentium qui mollitia. Et molestias omnis. Est nisi sed.",
-                      "Provident laborum dolores. Eligendi rerum quasi. Qui ex quidem."
+                      "Explicabo expedita voluptatem. Est facilis dolores. Corporis iusto nam.",
+                      "Architecto inventore aut. Quaerat inventore mollitia. Id omnis quia.",
+                      "Cum quis sapiente. Aut soluta numquam. Voluptatem nam nisi."
                     ],
                     "misconceptions": [
-                      "Debitis modi harum. Qui et cupiditate. Qui dicta asperiores.",
-                      "Numquam molestias porro. Repellendus sapiente omnis. Magnam recusandae consequatur.",
-                      "Et error alias. Quasi natus aut. Eveniet magnam minus."
+                      "Voluptas maiores inventore. Tempore est veritatis. Ab nemo et.",
+                      "Voluptatem aliquam voluptatem. Sit perferendis ipsam. Adipisci aut autem.",
+                      "Quo voluptate eum. In consequatur praesentium. Eius est tempora."
                     ],
                     "id": 1
                   },
                   {
-                    "name": "Joseph J. Thomson",
+                    "name": "Franz Boas",
                     "summary": "Lesson 2",
-                    "core_knowledge": "Natus non pariatur. Quae et quam. Eum nesciunt quis.\n\nIncidunt ex eum. Modi sapiente est. Ipsum fugiat aliquam.\n\nQui cumque eaque. Sint dignissimos deleniti. Excepturi nam vitae.",
-                    "previous_knowledge": "Maxime laborum porro. Quia nihil natus. Sed aut voluptas.\n\nNon et et. Vero sapiente non. Et ipsa ratione.\n\nUnde eum at. Fugiat et a. Similique excepturi quibusdam.",
+                    "core_knowledge": "Quia cum aut. Repellat dolor laborum. Provident et tempora.\n\nSit odio tempore. Minima nesciunt est. Nemo dolorem voluptate.\n\nArchitecto necessitatibus facilis. Similique libero architecto. Alias nemo ullam.",
+                    "previous_knowledge": "Assumenda qui eveniet. Voluptatem nihil delectus. Ut autem sed.\n\nAutem velit atque. Praesentium et voluptatem. Praesentium qui explicabo.\n\nQuos ut praesentium. Eius qui sed. Repellat molestias dolor.",
                     "vocabulary": [
-                      "Tenetur dolorum ab. Aut qui ut. Minus tempora sit.",
-                      "Provident velit et. Doloribus eligendi nemo. Expedita dicta sint.",
-                      "Est doloremque commodi. Similique et ipsum. Eos quaerat tempora."
+                      "Debitis recusandae inventore. Repudiandae asperiores pariatur. Qui et omnis.",
+                      "Non enim quia. Odit eligendi necessitatibus. Aut cum ducimus.",
+                      "Sed dolorem dolores. Necessitatibus ea eligendi. Odit distinctio minus."
                     ],
                     "misconceptions": [
-                      "Necessitatibus cumque nesciunt. Ut tempore atque. Nemo ut sed.",
-                      "Temporibus animi voluptatibus. Libero aperiam repellat. Ex architecto veritatis.",
-                      "Iusto et tempore. Doloremque consequatur necessitatibus. Dolores illo numquam."
+                      "Eos sunt tempore. Sed debitis molestiae. Voluptate eligendi sunt.",
+                      "Qui aut officia. Ratione voluptatem sit. Ex quia et.",
+                      "Tenetur velit tempora. Sed sit a. Qui expedita quia."
                     ],
                     "id": 2
                   }
@@ -286,19 +313,19 @@
             "description": "lesson found",
             "examples": {
               "application/json": {
-                "name": "Edward O. Wilson",
+                "name": "Dmitri Mendeleev",
                 "summary": "Lesson 3",
-                "core_knowledge": "Eaque voluptas repellat. Quos vitae similique. Qui quia perspiciatis.\n\nNecessitatibus eum odio. Quia libero aperiam. Asperiores cum non.\n\nEst omnis facere. Exercitationem aut maxime. Distinctio sed qui.",
-                "previous_knowledge": "Numquam excepturi maiores. Nisi totam molestiae. Ipsum enim aliquam.\n\nRerum suscipit maiores. Minus dolores iste. Ea ea sit.\n\nSunt eum vel. Recusandae tenetur nihil. Possimus quia repudiandae.",
+                "core_knowledge": "Voluptates quia iure. Aliquam alias aut. Nihil ea et.\n\nMolestiae vitae ullam. Molestias debitis ducimus. Temporibus asperiores quia.\n\nSapiente quia atque. Rerum corporis accusamus. Soluta quos distinctio.",
+                "previous_knowledge": "Sed non velit. Est earum autem. Rerum omnis et.\n\nQuam ea autem. Dignissimos enim eum. Autem accusantium eligendi.\n\nSaepe ipsa ullam. Dolorem debitis ad. Dolorem deleniti aliquid.",
                 "vocabulary": [
-                  "Eum id et. Et vero aut. Voluptatibus repudiandae dicta.",
-                  "Sed quibusdam et. Hic dolorem voluptatem. Sed exercitationem asperiores.",
-                  "Nemo perspiciatis fuga. Nihil sunt velit. Quos ut facere."
+                  "Ut tempora blanditiis. Culpa fugiat est. Qui nihil omnis.",
+                  "Aut cupiditate qui. Debitis itaque autem. Explicabo repudiandae ut.",
+                  "Natus aliquid quam. Animi minus explicabo. Aut repudiandae iste."
                 ],
                 "misconceptions": [
-                  "Tempore et minus. Omnis deleniti esse. Eos sint consequuntur.",
-                  "Qui optio explicabo. Et quo voluptatibus. Expedita delectus voluptas.",
-                  "Impedit eum magni. Et et qui. Rerum nulla quasi."
+                  "Rerum at voluptatem. Explicabo error voluptatem. Quasi nemo veniam.",
+                  "Debitis consequatur ducimus. Rem non voluptatem. Numquam unde culpa.",
+                  "Accusantium et in. Nisi quasi eveniet. Et ea nesciunt."
                 ],
                 "id": 1
               }
@@ -366,15 +393,15 @@
               "application/json": [
                 [
                   {
-                    "name": "Animi",
-                    "overview": "Fugit aut ut. Non omnis repellendus. Ut quia eaque.",
-                    "benefits": "Dolore officiis ad. Soluta molestias deleniti. Harum vitae recusandae.\n\nSed id et. Et veniam reiciendis. Enim nostrum ratione.\n\nSuscipit deserunt dicta. Ea aliquid delectus. Libero veritatis sunt.",
+                    "name": "Aut",
+                    "overview": "Est blanditiis autem. Natus sint totam. Repudiandae placeat quia.",
+                    "benefits": "Nobis aliquid velit. Non rerum at. Reiciendis a itaque.\n\nExercitationem est soluta. Ex quam cumque. Consequatur numquam et.\n\nExcepturi corrupti repellat. Ut aut reprehenderit. Nostrum magni asperiores.",
                     "id": 1
                   },
                   {
-                    "name": "Quisquam",
-                    "overview": "Quo placeat eum. Non pariatur dicta. Consectetur soluta enim.",
-                    "benefits": "Quo eligendi nemo. Unde provident omnis. Tempora tempore eum.\n\nSint architecto tempore. Cumque consequatur occaecati. Repellendus in animi.\n\nEa suscipit veritatis. Aut nam nulla. Nihil dolorem aut.",
+                    "name": "Aut",
+                    "overview": "Corporis blanditiis ut. Velit hic ipsum. Fugit sit omnis.",
+                    "benefits": "Totam molestias deleniti. Et eaque rerum. Molestiae excepturi a.\n\nEst incidunt corporis. Iure et dolor. Incidunt voluptatem quis.\n\nPraesentium accusamus ipsa. Officiis similique est. Molestiae minima delectus.",
                     "id": 2
                   }
                 ]
@@ -437,65 +464,65 @@
             "description": "unit found",
             "examples": {
               "application/json": {
-                "name": "Accusamus",
-                "overview": "Nemo repellendus et. Voluptatum voluptatem qui. Quis eveniet et.",
-                "benefits": "Tenetur quae rerum. Reiciendis ea aut. Dignissimos quia et.\n\nEa distinctio nihil. Fugiat sit cum. Qui veniam ut.\n\nAutem cum voluptatem. Nisi molestias totam. Et quo sunt.",
+                "name": "Nihil",
+                "overview": "Suscipit numquam ea. Eius voluptas et. Dolores dolorem vel.",
+                "benefits": "Assumenda libero numquam. Saepe minus unde. Provident non et.\n\nLaudantium ut est. Laborum hic qui. Facilis nulla et.\n\nDeserunt aliquam consequuntur. Officia non accusantium. Qui animi sed.",
                 "id": 1,
                 "complete_curriculum_programme": {
-                  "name": "West Johnson University",
-                  "overview": "Optio repellat totam. Atque exercitationem nostrum. Ipsam blanditiis eligendi.",
-                  "benefits": "Distinctio ducimus in. Blanditiis et ut. Ratione aliquam delectus.\n\nQuod quo alias. Distinctio ipsum sed. Itaque quia aut.\n\nOdit placeat illum. Neque nobis aut. Doloribus aliquid quis.",
+                  "name": "Northern Wisconsin University",
+                  "overview": "Quis illo fugiat. Ut explicabo totam. Eligendi ipsa incidunt.",
+                  "benefits": "Et ipsa distinctio. Error optio excepturi. Quia quidem hic.\n\nEt sed minima. Accusamus expedita eos. Aperiam omnis corporis.\n\nMaiores eius error. Nemo quam culpa. Et velit qui.",
                   "id": 1
                 },
                 "lessons": [
                   {
-                    "name": "William Bayliss",
+                    "name": "Ernst Haeckel",
                     "summary": "Lesson 4",
-                    "core_knowledge": "Asperiores deserunt consequatur. Sunt fugit sed. Ducimus ut et.\n\nQuaerat dolor explicabo. Inventore ut ipsa. Sed necessitatibus fugiat.\n\nOmnis amet possimus. Debitis eum dolores. Laudantium iure fugit.",
-                    "previous_knowledge": "Quisquam eos eveniet. Ratione consectetur consequatur. Consequatur enim excepturi.\n\nId ut illum. Dolore iste tempora. Et sit eum.\n\nPlaceat quia quae. Et repellendus voluptas. Ea quis qui.",
+                    "core_knowledge": "Et nemo soluta. Ratione iure omnis. Qui soluta vero.\n\nVero odit dolore. Quos minus quis. Eum et mollitia.\n\nSapiente temporibus distinctio. Laudantium quis itaque. In ipsa voluptatum.",
+                    "previous_knowledge": "Saepe excepturi quidem. Possimus earum consequuntur. Qui officia quis.\n\nEaque officiis eveniet. Omnis omnis dolorem. Sed et eius.\n\nUnde quos aut. Molestiae vel voluptatem. Dolor dicta perspiciatis.",
                     "vocabulary": [
-                      "Porro et et. Et dicta quod. In id illo.",
-                      "Nostrum et ab. Repellat ratione hic. Dolor et neque.",
-                      "Sequi ut qui. Ut vero magnam. Et numquam cumque."
+                      "Soluta animi adipisci. Animi dolor tempora. Eveniet accusamus quis.",
+                      "Consequatur in facilis. Maxime laborum est. Voluptatum facere recusandae.",
+                      "Quas perspiciatis amet. In similique nam. Est sint eligendi."
                     ],
                     "misconceptions": [
-                      "Dolore itaque rerum. Vitae assumenda laudantium. Velit omnis qui.",
-                      "Quis accusamus est. Rerum perferendis quo. Saepe deleniti debitis.",
-                      "Ut dolor eos. Dolore quidem aliquid. Amet fugit autem."
+                      "Sunt saepe et. Aut et eaque. Illum architecto blanditiis.",
+                      "Ut est eos. Aut laboriosam assumenda. Quaerat non id.",
+                      "Sed molestias voluptatem. Fugiat sint dolores. Quis optio totam."
                     ],
                     "id": 1
                   },
                   {
-                    "name": "Hermann von Helmholtz",
+                    "name": "Trofim Lysenko",
                     "summary": "Lesson 5",
-                    "core_knowledge": "In et ut. Fuga optio pariatur. Ut a nisi.\n\nConsequatur dolor vel. Autem quo debitis. Consequatur porro ut.\n\nDolor maiores impedit. Earum est nihil. Aliquam soluta architecto.",
-                    "previous_knowledge": "Explicabo voluptatem non. Facilis vitae aperiam. Molestias modi sint.\n\nNeque eligendi voluptatibus. Modi doloribus vero. Nisi laboriosam a.\n\nEnim quod expedita. Culpa deserunt id. Quis aut quia.",
+                    "core_knowledge": "Soluta necessitatibus debitis. Nesciunt qui atque. Tempora pariatur cupiditate.\n\nDolor ex autem. Distinctio quis fugit. Quibusdam sunt accusamus.\n\nEa provident ex. Facere ipsum vel. Iure asperiores autem.",
+                    "previous_knowledge": "Nesciunt tenetur sunt. Excepturi non qui. Quo non sit.\n\nQuia non nisi. Libero tenetur dolores. Possimus ea aut.\n\nEt non aut. Et rerum expedita. Modi nisi in.",
                     "vocabulary": [
-                      "Rerum deserunt a. Sunt quia qui. Deleniti facere iure.",
-                      "Eum cum rerum. Delectus pariatur ut. Est quis fuga.",
-                      "Rerum exercitationem occaecati. Fuga id harum. Deserunt et aut."
+                      "Eaque impedit qui. Fugiat sapiente aut. Et qui accusantium.",
+                      "Vel non qui. Rerum voluptatum officia. Qui nemo ut.",
+                      "Exercitationem praesentium dolores. Voluptatibus totam ex. Aut animi sit."
                     ],
                     "misconceptions": [
-                      "Nam omnis quisquam. Et commodi voluptatem. Enim ea debitis.",
-                      "Sint harum quis. Aut fugiat et. Ut eum debitis.",
-                      "Eos asperiores numquam. Accusantium nam harum. Fugiat aperiam omnis."
+                      "Officiis illum et. Itaque atque sed. Qui recusandae laborum.",
+                      "Tempora ex enim. Incidunt quia eius. Rerum pariatur quibusdam.",
+                      "Ipsa laudantium iusto. Delectus cumque cupiditate. Ipsum rem officia."
                     ],
                     "id": 2
                   },
                   {
-                    "name": "Gregor Mendel",
+                    "name": "B. F. Skinner",
                     "summary": "Lesson 6",
-                    "core_knowledge": "Inventore et nostrum. Inventore eum consequuntur. Et velit quia.\n\nReprehenderit officia occaecati. Cum consequatur qui. Atque enim debitis.\n\nDolorum aut est. Earum sed sint. Omnis inventore ab.",
-                    "previous_knowledge": "Aliquam labore rerum. Illum ut cumque. Repellendus recusandae culpa.\n\nUnde nemo quas. Natus quisquam necessitatibus. Beatae at enim.\n\nEaque dolorem quibusdam. Ab non illo. Architecto molestiae in.",
+                    "core_knowledge": "Vel dolorum et. Rerum voluptas porro. Eos corporis saepe.\n\nQuia sed velit. Distinctio corporis qui. Deleniti ea nemo.\n\nDicta sunt culpa. Voluptatibus voluptate consectetur. Architecto voluptatem repellat.",
+                    "previous_knowledge": "A sapiente esse. Inventore accusamus expedita. Quo at repellendus.\n\nMolestias ipsam et. Fuga quia ipsam. Voluptate iusto quo.\n\nAt qui voluptatem. Enim iusto totam. Ipsam mollitia hic.",
                     "vocabulary": [
-                      "Expedita sunt similique. Sint nesciunt quisquam. Eos similique accusamus.",
-                      "Provident odio culpa. Aut voluptas asperiores. Fuga aut est.",
-                      "Numquam ut magnam. Veniam pariatur ut. Autem nostrum minima."
+                      "Dolorem repudiandae placeat. Temporibus et accusantium. Autem commodi quas.",
+                      "Sit amet et. Quas nesciunt est. Eveniet exercitationem dolor.",
+                      "Eveniet fugit veritatis. Laboriosam pariatur tenetur. Omnis voluptatem et."
                     ],
                     "misconceptions": [
-                      "Est molestias in. In vitae quia. Ut repellendus dolores.",
-                      "Ipsum culpa est. Sequi esse mollitia. In dolorem nemo.",
-                      "Debitis dolores perspiciatis. Nisi illo inventore. Dolore sit mollitia."
+                      "Voluptatem nobis maxime. Ut illo repellendus. Aut repudiandae fugiat.",
+                      "Pariatur deleniti vero. Ea architecto et. Aperiam quasi qui.",
+                      "Hic laborum est. Non dolores omnis. Nobis non ipsa."
                     ],
                     "id": 3
                   }

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -68,8 +68,7 @@
                 "ccp": {
                   "name": "CCP 2",
                   "overview": "Overview",
-                  "benefits": "Benefits",
-                  "id": 1
+                  "benefits": "Benefits"
                 }
               }
             }
@@ -188,8 +187,7 @@
                 "ccp": {
                   "name": "CCP 4",
                   "overview": "Overview",
-                  "benefits": "Benefits",
-                  "id": 1
+                  "benefits": "Benefits"
                 }
               }
             }
@@ -202,9 +200,9 @@
     },
     "/ccps/{ccp_id}/units/{unit_id}/lessons": {
       "get": {
-        "summary": "Retrieves all lessons belonging to the specified CCP and unit",
+        "summary": "retrieves all lessons belonging to the specified CCP and unit",
         "tags": [
-          "CCP"
+          "Lesson"
         ],
         "parameters": [
           {
@@ -304,13 +302,63 @@
             }
           }
         }
+      },
+      "post": {
+        "summary": "creates a lesson belonging to the specified unit",
+        "tags": [
+          "Lesson"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "lesson created",
+            "examples": {
+              "application/json": {
+                "lesson": {
+                  "name": "Lesson 3",
+                  "summary": "Lesson 3",
+                  "core_knowledge": "Core knowledge",
+                  "previous_knowledge": "Previous knowledge",
+                  "vocabulary": [
+                    "Subtraction",
+                    "Division",
+                    "Multiplication"
+                  ],
+                  "misconceptions": [
+                    "Fractions are not natural numbers"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid unit"
+          }
+        }
       }
     },
     "/ccps/{ccp_id}/units/{unit_id}/lessons/{id}": {
       "get": {
-        "summary": "Retrieves a single lesson belonging to the specified CCP and unit",
+        "summary": "retrieves a single lesson belonging to the specified CCP and unit",
         "tags": [
-          "CCP"
+          "Lesson"
         ],
         "parameters": [
           {
@@ -343,8 +391,8 @@
             "description": "lesson found",
             "examples": {
               "application/json": {
-                "name": "Lesson 3",
-                "summary": "Lesson 3",
+                "name": "Lesson 4",
+                "summary": "Lesson 4",
                 "core_knowledge": "Core knowledge",
                 "previous_knowledge": "Previous knowledge",
                 "vocabulary": [
@@ -396,13 +444,71 @@
             }
           }
         }
+      },
+      "patch": {
+        "summary": "update the referenced lesson",
+        "tags": [
+          "Lesson"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "lesson updated",
+            "examples": {
+              "application/json": {
+                "lesson": {
+                  "name": "Lesson 5",
+                  "summary": "Lesson 5",
+                  "core_knowledge": "Core knowledge",
+                  "previous_knowledge": "Previous knowledge",
+                  "vocabulary": [
+                    "Subtraction",
+                    "Division",
+                    "Multiplication"
+                  ],
+                  "misconceptions": [
+                    "Fractions are not natural numbers"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid lesson"
+          }
+        }
       }
     },
     "/ccps/{ccp_id}/units": {
       "get": {
-        "summary": "Retrieves all units belonging to the provided CCP",
+        "summary": "retrieves all units belonging to the provided CCP",
         "tags": [
-          "CCP"
+          "Unit"
         ],
         "parameters": [
           {
@@ -461,13 +567,47 @@
             }
           }
         }
+      },
+      "post": {
+        "summary": "creates a new unit belonging to the specified CCP",
+        "tags": [
+          "Unit"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "unit created",
+            "examples": {
+              "application/json": {
+                "unit": {
+                  "name": "Unit 5",
+                  "overview": "Overview",
+                  "benefits": "Benefits",
+                  "id": 1
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid unit"
+          }
+        }
       }
     },
     "/ccps/{ccp_id}/units/{id}": {
       "get": {
-        "summary": "Retrieves a single unit belonging to the specified CCP",
+        "summary": "retrieves a single unit belonging to the specified CCP",
         "tags": [
-          "CCP"
+          "Unit"
         ],
         "parameters": [
           {
@@ -492,7 +632,7 @@
             "description": "unit found",
             "examples": {
               "application/json": {
-                "name": "Unit 5",
+                "name": "Unit 6",
                 "overview": "Overview",
                 "benefits": "Benefits",
                 "id": 1,
@@ -504,8 +644,8 @@
                 },
                 "lessons": [
                   {
-                    "name": "Lesson 4",
-                    "summary": "Lesson 4",
+                    "name": "Lesson 6",
+                    "summary": "Lesson 6",
                     "core_knowledge": "Core knowledge",
                     "previous_knowledge": "Previous knowledge",
                     "vocabulary": [
@@ -519,8 +659,8 @@
                     "id": 1
                   },
                   {
-                    "name": "Lesson 5",
-                    "summary": "Lesson 5",
+                    "name": "Lesson 7",
+                    "summary": "Lesson 7",
                     "core_knowledge": "Core knowledge",
                     "previous_knowledge": "Previous knowledge",
                     "vocabulary": [
@@ -534,8 +674,8 @@
                     "id": 2
                   },
                   {
-                    "name": "Lesson 6",
-                    "summary": "Lesson 6",
+                    "name": "Lesson 8",
+                    "summary": "Lesson 8",
                     "core_knowledge": "Core knowledge",
                     "previous_knowledge": "Previous knowledge",
                     "vocabulary": [
@@ -624,6 +764,47 @@
                 }
               }
             }
+          }
+        }
+      },
+      "patch": {
+        "summary": "update the referenced unit",
+        "tags": [
+          "Unit"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "unit updated",
+            "examples": {
+              "application/json": {
+                "unit": {
+                  "name": "Unit 7",
+                  "overview": "Overview",
+                  "benefits": "Benefits"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid unit"
           }
         }
       }

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -18,9 +18,9 @@
             "examples": {
               "application/json": [
                 {
-                  "name": "West Kunde Academy",
-                  "overview": "Aut tempore rerum. Rem repudiandae accusamus. Consectetur laborum omnis.",
-                  "benefits": "Cupiditate in praesentium. Nihil est reprehenderit. Eos et eveniet.\n\nEveniet aut dolores. Quaerat atque debitis. Est autem eligendi.\n\nUnde nihil sit. Occaecati voluptatem assumenda. Consectetur aut eos.",
+                  "name": "CCP 1",
+                  "overview": "Overview",
+                  "benefits": "Benefits",
                   "id": 1
                 }
               ]
@@ -66,9 +66,9 @@
             "examples": {
               "application/json": {
                 "ccp": {
-                  "name": "West Minnesota Academy",
-                  "overview": "Consequatur id in. Blanditiis aspernatur est. Est et dolores.",
-                  "benefits": "Ut sequi sint. Nobis accusamus a. Quis sunt facere.\n\nEt veniam quaerat. Delectus laudantium quaerat. Molestiae atque voluptatem.\n\nDolore ipsam cumque. Aliquam quam corporis. Ab saepe cumque.",
+                  "name": "CCP 2",
+                  "overview": "Overview",
+                  "benefits": "Benefits",
                   "id": 1
                 }
               }
@@ -101,21 +101,21 @@
             "description": "ccp found",
             "examples": {
               "application/json": {
-                "name": "Southern North Dakota Academy",
-                "overview": "Illum voluptatem aut. Non veniam eveniet. Molestiae et ipsum.",
-                "benefits": "Necessitatibus fuga similique. Non minima sunt. Nam labore occaecati.\n\nVero sit ullam. Ab qui a. Quia sit inventore.\n\nExercitationem magni placeat. Consectetur repellendus dolores. Saepe explicabo dolorum.",
+                "name": "CCP 3",
+                "overview": "Overview",
+                "benefits": "Benefits",
                 "id": 1,
                 "units": [
                   {
-                    "name": "Dolore",
-                    "overview": "Magni ratione voluptatem. Mollitia exercitationem at. Consequuntur voluptatum quisquam.",
-                    "benefits": "Incidunt et sit. Quis dolorem iste. Accusamus rerum numquam.\n\nEt quo itaque. Dolor ut nam. Et assumenda unde.\n\nNihil voluptatem accusamus. Fuga inventore illo. Omnis quisquam similique.",
+                    "name": "Unit 1",
+                    "overview": "Overview",
+                    "benefits": "Benefits",
                     "id": 1
                   },
                   {
-                    "name": "Qui",
-                    "overview": "Quaerat itaque blanditiis. Aut fugit quasi. Veniam alias quia.",
-                    "benefits": "Debitis in facilis. Quo aut et. Animi molestiae pariatur.\n\nConsequatur est consequuntur. Vel voluptas sit. Ipsa quisquam voluptas.\n\nEt nihil doloribus. Facilis omnis quo. Omnis reiciendis impedit.",
+                    "name": "Unit 2",
+                    "overview": "Overview",
+                    "benefits": "Benefits",
                     "id": 2
                   }
                 ]
@@ -186,9 +186,9 @@
             "examples": {
               "application/json": {
                 "ccp": {
-                  "name": "North Ankunding",
-                  "overview": "Magnam enim perspiciatis. Labore rerum quis. Culpa deleniti qui.",
-                  "benefits": "Et sit et. Asperiores sapiente molestias. Reiciendis enim minima.\n\nArchitecto corporis animi. Doloribus quasi deserunt. Recusandae aut dicta.\n\nDolor quo aliquam. Sit aut iusto. Aspernatur quis culpa.",
+                  "name": "CCP 4",
+                  "overview": "Overview",
+                  "benefits": "Benefits",
                   "id": 1
                 }
               }
@@ -231,36 +231,32 @@
               "application/json": [
                 [
                   {
-                    "name": "Comte de Buffon",
+                    "name": "Lesson 1",
                     "summary": "Lesson 1",
-                    "core_knowledge": "Adipisci a repellendus. Iusto recusandae ut. Ab soluta a.\n\nEt molestiae enim. Minus sequi quia. Cum asperiores blanditiis.\n\nQuos recusandae tempora. Quam provident a. Molestiae voluptates consectetur.",
-                    "previous_knowledge": "Tenetur id reiciendis. Beatae laborum dicta. Veritatis dolor ducimus.\n\nVitae quae aut. Quae illo qui. Tenetur sint dolor.\n\nMollitia provident qui. Recusandae explicabo voluptatem. Quidem omnis totam.",
+                    "core_knowledge": "Core knowledge",
+                    "previous_knowledge": "Previous knowledge",
                     "vocabulary": [
-                      "Sit repudiandae ut. Iste unde tempora. Ut praesentium maiores.",
-                      "Voluptatem dignissimos et. Est accusamus iusto. Voluptatum perspiciatis incidunt.",
-                      "Doloremque voluptatibus voluptates. Accusantium iusto earum. Omnis laboriosam qui."
+                      "Subtraction",
+                      "Division",
+                      "Multiplication"
                     ],
                     "misconceptions": [
-                      "Quia tempore non. Vero labore quia. Dolore quo quisquam.",
-                      "Deleniti et nulla. Quo amet reiciendis. Iste quod rerum.",
-                      "Eligendi sint quibusdam. Molestiae assumenda alias. Provident dicta debitis."
+                      "Fractions are not natural numbers"
                     ],
                     "id": 1
                   },
                   {
-                    "name": "Linus Pauling",
+                    "name": "Lesson 2",
                     "summary": "Lesson 2",
-                    "core_knowledge": "Ipsam consectetur ex. Qui architecto ut. Aut aut voluptatum.\n\nOptio inventore ex. Est placeat provident. Corporis sit quo.\n\nEt eos possimus. Quia quidem ipsum. Voluptatem molestias dolorem.",
-                    "previous_knowledge": "At voluptatum est. Qui sunt voluptatum. Qui nobis alias.\n\nProvident nulla et. Repellendus fugiat est. Unde repellat doloribus.\n\nQuis vel et. Animi est aliquam. Quod fugiat ut.",
+                    "core_knowledge": "Core knowledge",
+                    "previous_knowledge": "Previous knowledge",
                     "vocabulary": [
-                      "Aut ducimus praesentium. Cumque eligendi ut. Qui adipisci quo.",
-                      "Debitis ex voluptas. Veritatis similique voluptas. Ducimus non magnam.",
-                      "Et ea qui. Sequi laboriosam illo. Ut id aut."
+                      "Subtraction",
+                      "Division",
+                      "Multiplication"
                     ],
                     "misconceptions": [
-                      "Reprehenderit pariatur aut. Iure sapiente consequuntur. Maxime facere molestias.",
-                      "Ea est repellat. Id consectetur possimus. Corporis ullam porro.",
-                      "Soluta eos occaecati. Rerum voluptatem quidem. Numquam dolor rem."
+                      "Fractions are not natural numbers"
                     ],
                     "id": 2
                   }
@@ -347,19 +343,17 @@
             "description": "lesson found",
             "examples": {
               "application/json": {
-                "name": "Enrico Fermi",
+                "name": "Lesson 3",
                 "summary": "Lesson 3",
-                "core_knowledge": "Dolores veniam quibusdam. Aperiam qui quia. Eum hic eum.\n\nQuaerat ea perferendis. Numquam velit molestiae. Ut dignissimos quidem.\n\nNon autem fuga. Vitae magni saepe. Quaerat debitis voluptatem.",
-                "previous_knowledge": "Quae beatae placeat. Quo minima ratione. Molestiae vel officiis.\n\nError qui ut. Est magni voluptatem. Eveniet molestiae voluptates.\n\nSapiente saepe et. Porro dolorum et. Et est dolore.",
+                "core_knowledge": "Core knowledge",
+                "previous_knowledge": "Previous knowledge",
                 "vocabulary": [
-                  "Non deserunt voluptas. Delectus minus sapiente. Et quaerat error.",
-                  "Facere delectus aut. At eveniet in. Sit quis et.",
-                  "Et iste consequuntur. Consequuntur rerum aut. Neque quaerat autem."
+                  "Subtraction",
+                  "Division",
+                  "Multiplication"
                 ],
                 "misconceptions": [
-                  "Cumque dolores at. Voluptas ex dignissimos. Sint fuga repudiandae.",
-                  "Laudantium optio natus. Nostrum et debitis. Quibusdam rerum quo.",
-                  "Saepe voluptatem omnis. Accusantium sit modi. At iste modi."
+                  "Fractions are not natural numbers"
                 ],
                 "id": 1
               }
@@ -427,15 +421,15 @@
               "application/json": [
                 [
                   {
-                    "name": "Fugit",
-                    "overview": "Provident officia minima. Qui dolor excepturi. Aperiam omnis est.",
-                    "benefits": "Sunt est aut. Magnam ullam autem. Unde sed iure.\n\nIllum perspiciatis quo. Voluptatem necessitatibus qui. Sit qui placeat.\n\nDolorem aperiam perferendis. Sint temporibus ut. Magni adipisci ducimus.",
+                    "name": "Unit 3",
+                    "overview": "Overview",
+                    "benefits": "Benefits",
                     "id": 1
                   },
                   {
-                    "name": "Pariatur",
-                    "overview": "Ut ipsum ex. Maiores veniam dolores. Facere aut suscipit.",
-                    "benefits": "Molestias ipsum iure. Perspiciatis a excepturi. Quidem harum assumenda.\n\nQuae alias cum. Rerum perspiciatis dolorem. Voluptate nesciunt libero.\n\nSed voluptatem provident. A qui qui. Eius veniam enim.",
+                    "name": "Unit 4",
+                    "overview": "Overview",
+                    "benefits": "Benefits",
                     "id": 2
                   }
                 ]
@@ -498,65 +492,59 @@
             "description": "unit found",
             "examples": {
               "application/json": {
-                "name": "Dolorem",
-                "overview": "Tempora culpa modi. Occaecati excepturi vel. Voluptate eius qui.",
-                "benefits": "Dignissimos similique ea. Voluptatem alias modi. Voluptatum tempora rerum.\n\nVelit molestiae et. Laudantium veniam est. Assumenda magnam perspiciatis.\n\nBeatae aperiam ratione. Tempora inventore modi. Quam exercitationem ea.",
+                "name": "Unit 5",
+                "overview": "Overview",
+                "benefits": "Benefits",
                 "id": 1,
                 "complete_curriculum_programme": {
-                  "name": "East Georgia College",
-                  "overview": "Exercitationem libero et. Ut enim itaque. Itaque totam excepturi.",
-                  "benefits": "Consequatur soluta natus. Nulla omnis ea. Perferendis velit ut.\n\nOmnis quisquam inventore. Et a sequi. Sapiente perspiciatis excepturi.\n\nDeleniti accusantium voluptatem. Ea dolore minima. Et et officiis.",
+                  "name": "CCP 5",
+                  "overview": "Overview",
+                  "benefits": "Benefits",
                   "id": 1
                 },
                 "lessons": [
                   {
-                    "name": "Archimedes",
+                    "name": "Lesson 4",
                     "summary": "Lesson 4",
-                    "core_knowledge": "Id rerum non. Voluptatibus non quo. Quis neque ut.\n\nQuia molestiae id. Qui sunt ea. Sequi dolores placeat.\n\nExpedita nesciunt sed. Dicta incidunt deleniti. Voluptatem ducimus cupiditate.",
-                    "previous_knowledge": "Pariatur voluptas maxime. Maxime non nemo. Fugiat alias rerum.\n\nNihil eos recusandae. Consequuntur inventore corporis. Minus temporibus et.\n\nAb vitae aspernatur. Repellat rerum ut. Ab possimus voluptatem.",
+                    "core_knowledge": "Core knowledge",
+                    "previous_knowledge": "Previous knowledge",
                     "vocabulary": [
-                      "Quaerat enim repellat. Itaque voluptatum qui. Corrupti quisquam non.",
-                      "Aut eos molestias. Quam qui ut. Ut quia dignissimos.",
-                      "Velit vitae voluptatem. Est ducimus quasi. Repellat et officiis."
+                      "Subtraction",
+                      "Division",
+                      "Multiplication"
                     ],
                     "misconceptions": [
-                      "Odit eaque fuga. Omnis distinctio provident. Illo rerum nam.",
-                      "Neque quia officiis. Magni dolorem tempora. Ut dolores et.",
-                      "Tempore unde et. Et aut saepe. Quod debitis in."
+                      "Fractions are not natural numbers"
                     ],
                     "id": 1
                   },
                   {
-                    "name": "John von Neumann",
+                    "name": "Lesson 5",
                     "summary": "Lesson 5",
-                    "core_knowledge": "Mollitia vel voluptate. Fuga unde eos. Est inventore nostrum.\n\nProvident aut est. Nam doloremque perspiciatis. Est ex quisquam.\n\nQuaerat ea maxime. Ab magnam sit. Voluptatem modi est.",
-                    "previous_knowledge": "Molestiae eligendi ab. Voluptatibus nisi tenetur. Cupiditate aut nisi.\n\nInventore quia et. Enim rerum ratione. Dolores sed suscipit.\n\nCum autem praesentium. Corrupti quis magni. Non repudiandae non.",
+                    "core_knowledge": "Core knowledge",
+                    "previous_knowledge": "Previous knowledge",
                     "vocabulary": [
-                      "Aut eum nobis. Ab velit quia. Unde adipisci corrupti.",
-                      "Est in impedit. Dolorem dicta maiores. Reprehenderit nihil ut.",
-                      "Iusto dolorum sit. Ipsum sit aut. Facere voluptas ullam."
+                      "Subtraction",
+                      "Division",
+                      "Multiplication"
                     ],
                     "misconceptions": [
-                      "Hic rerum praesentium. Rerum temporibus aut. Est est quo.",
-                      "Labore minus eum. Modi asperiores possimus. Temporibus qui eos.",
-                      "Officiis aspernatur aperiam. Ea dolor autem. Omnis in quis."
+                      "Fractions are not natural numbers"
                     ],
                     "id": 2
                   },
                   {
-                    "name": "Arthur Eddington",
+                    "name": "Lesson 6",
                     "summary": "Lesson 6",
-                    "core_knowledge": "Accusantium voluptatem rerum. Voluptatem quas est. Assumenda ad aperiam.\n\nLaborum amet sunt. Corporis in impedit. Harum eum vel.\n\nQuasi nisi exercitationem. Facilis quos esse. Ullam aut saepe.",
-                    "previous_knowledge": "Aliquid eum nihil. Et ut sint. Laboriosam mollitia beatae.\n\nQuos ullam deserunt. Maiores laborum laboriosam. Libero sunt eum.\n\nLibero molestiae sit. Adipisci libero similique. Cum aut a.",
+                    "core_knowledge": "Core knowledge",
+                    "previous_knowledge": "Previous knowledge",
                     "vocabulary": [
-                      "Laborum voluptas est. Inventore laudantium voluptas. Aut et rem.",
-                      "Eveniet qui est. Laudantium odit maxime. Sit nulla cumque.",
-                      "Aliquid commodi porro. Dolorem dolores error. Dolorem maiores autem."
+                      "Subtraction",
+                      "Division",
+                      "Multiplication"
                     ],
                     "misconceptions": [
-                      "Aperiam doloribus exercitationem. Ipsam quos est. Qui qui nihil.",
-                      "Nisi enim et. Beatae minus quos. Minima qui aut.",
-                      "Provident exercitationem iste. Ea vero ut. Totam suscipit repudiandae."
+                      "Fractions are not natural numbers"
                     ],
                     "id": 3
                   }

--- a/spec/integration/api/v1/complete_curriculum_programmes_spec.rb
+++ b/spec/integration/api/v1/complete_curriculum_programmes_spec.rb
@@ -42,7 +42,24 @@ describe 'Complete curriculum programmes' do
           properties: {
             ccp: {
               type: :object,
-              proprties: {
+              properties: {
+                name: { type: :string },
+                benefits: { type: :string },
+                overview: { type: :string }
+              },
+              required: %i(name benefits overview)
+            },
+            required: %i(ccp)
+          }
+        }
+      )
+
+      request_body_json(
+        schema: {
+          properties: {
+            ccp: {
+              type: :object,
+              properties: {
                 name: { type: :string },
                 benefits: { type: :string },
                 overview: { type: :string }
@@ -139,7 +156,24 @@ describe 'Complete curriculum programmes' do
           properties: {
             ccp: {
               type: :object,
-              proprties: {
+              properties: {
+                name: { type: :string },
+                benefits: { type: :string },
+                overview: { type: :string }
+              },
+              required: %i(name benefits overview)
+            },
+            required: %i(ccp)
+          }
+        }
+      )
+
+      request_body_json(
+        schema: {
+          properties: {
+            ccp: {
+              type: :object,
+              properties: {
                 name: { type: :string },
                 benefits: { type: :string },
                 overview: { type: :string }

--- a/spec/integration/api/v1/complete_curriculum_programmes_spec.rb
+++ b/spec/integration/api/v1/complete_curriculum_programmes_spec.rb
@@ -57,7 +57,7 @@ describe 'Complete curriculum programmes' do
       response(201, 'ccp created') do
         let!(:ccp_params) { { ccp: FactoryBot.attributes_for(:ccp) } }
 
-        examples('application/json': { ccp: example_ccp })
+        examples('application/json': { ccp: FactoryBot.attributes_for(:ccp) })
 
         run_test! do |response|
           # all of the values in the payload should be present in the returned
@@ -152,7 +152,7 @@ describe 'Complete curriculum programmes' do
       )
 
       response(200, 'ccp updated') do
-        examples('application/json': { ccp: example_ccp })
+        examples('application/json': { ccp: FactoryBot.attributes_for(:ccp) })
 
         run_test! do |response|
           JSON.parse(response.body).with_indifferent_access.tap do |json|

--- a/spec/integration/api/v1/complete_curriculum_programmes_spec.rb
+++ b/spec/integration/api/v1/complete_curriculum_programmes_spec.rb
@@ -2,13 +2,13 @@ require 'swagger_helper'
 
 describe 'Complete curriculum programmes' do
   path('/ccps') do
-    get('retrieves all complete curriculum programmes (CCPs)') do
+    get('retrieves all complete curriculum programmes') do
       tags('CCP')
       produces('application/json')
 
       let!(:ccps) { FactoryBot.create_list(:ccp, 2) }
 
-      response '200', 'ccps found' do
+      response 200, 'ccps found' do
         examples(
           'application/json': [example_ccp]
         )
@@ -29,6 +29,56 @@ describe 'Complete curriculum programmes' do
         run_test!
       end
     end
+
+    post('creates a new complete curriculum programme') do
+      tags('CCP')
+
+      consumes 'application/json'
+
+      parameter(
+        name: :ccp,
+        in: :body,
+        schema: {
+          properties: {
+            ccp: {
+              type: :object,
+              proprties: {
+                name: { type: :string },
+                benefits: { type: :string },
+                overview: { type: :string }
+              },
+              required: %i(name benefits overview)
+            },
+            required: %i(ccp)
+          }
+        }
+      )
+
+      response(201, 'ccp created') do
+        let!(:ccp) { { ccp: FactoryBot.attributes_for(:ccp) } }
+
+        examples('application/json': { ccp: example_ccp })
+
+        run_test! do |response|
+          # all of the values in the payload should be present in the returned
+          # JSON, along with some others added by saving (id, timestamps)
+
+          JSON.parse(response.body).with_indifferent_access.tap do |json|
+            ccp.dig(:ccp).each do |attribute, value|
+              expect(json[attribute]).to eql(value)
+            end
+          end
+        end
+      end
+
+      response(400, 'invalid ccp') do
+        let!(:ccp) { { ccp: FactoryBot.attributes_for(:ccp, name: '') } }
+
+        run_test! do |response|
+          expect(JSON.parse(response.body).dig('errors')).to include(%(Name can't be blank))
+        end
+      end
+    end
   end
 
   path('/ccps/{id}') do
@@ -41,7 +91,7 @@ describe 'Complete curriculum programmes' do
       let!(:ccp) { FactoryBot.create(:ccp) }
       let(:id) { ccp.id }
 
-      response('200', 'ccp found') do
+      response(200, 'ccp found') do
         examples('application/json': example_ccp.merge(units: example_units(2)))
 
         schema(

--- a/spec/integration/api/v1/lessons_spec.rb
+++ b/spec/integration/api/v1/lessons_spec.rb
@@ -2,8 +2,8 @@ require 'swagger_helper'
 
 describe 'Lessons' do
   path('/ccps/{ccp_id}/units/{unit_id}/lessons') do
-    get('Retrieves all lessons belonging to the specified CCP and unit') do
-      tags('CCP')
+    get('retrieves all lessons belonging to the specified CCP and unit') do
+      tags('Lesson')
       produces('application/json')
 
       let(:lesson) { FactoryBot.create(:lesson) }
@@ -40,11 +40,72 @@ describe 'Lessons' do
         run_test!
       end
     end
+
+    post('creates a lesson belonging to the specified unit') do
+      tags('Lesson')
+
+      let(:lesson) { FactoryBot.create(:lesson) }
+      let(:ccp_id) { lesson.unit.complete_curriculum_programme.id }
+      let(:unit_id) { lesson.unit.id }
+
+      consumes 'application/json'
+
+      parameter(name: :ccp_id, in: :path, type: :string, required: true)
+      parameter(name: :unit_id, in: :path, type: :string, required: true)
+
+      parameter(
+        name: :lesson_params,
+        in: :body,
+        schema: {
+          properties: {
+            lesson: {
+              type: :object,
+              properties: {
+                id: { type: :integer },
+                name: { type: :string },
+                summary: { type: :string },
+                core_knowledge: { type: :string },
+                previous_knowledge: { type: :string },
+                vocabulary: {
+                  type: :array, items: { type: :string }
+                },
+                misconceptions: {
+                  type: :array, items: { type: :string }
+                },
+              },
+              required: %i(unit)
+            }
+          }
+        }
+      )
+
+      response(201, 'lesson created') do
+        let!(:lesson_params) { { lesson: FactoryBot.attributes_for(:lesson) } }
+
+        examples('application/json': { lesson: FactoryBot.attributes_for(:lesson) })
+
+        run_test! do |response|
+          JSON.parse(response.body).with_indifferent_access.tap do |json|
+            lesson_params.dig(:lesson).each do |attribute, value|
+              expect(json[attribute]).to eql(value)
+            end
+          end
+        end
+      end
+
+      response(400, 'invalid unit') do
+        let!(:lesson_params) { { lesson: FactoryBot.attributes_for(:lesson, name: '') } }
+
+        run_test! do |response|
+          expect(JSON.parse(response.body).dig('errors')).to include(%(Name can't be blank))
+        end
+      end
+    end
   end
 
   path('/ccps/{ccp_id}/units/{unit_id}/lessons/{id}') do
-    get('Retrieves a single lesson belonging to the specified CCP and unit') do
-      tags('CCP')
+    get('retrieves a single lesson belonging to the specified CCP and unit') do
+      tags('Lesson')
       produces('application/json')
 
       let(:lesson) { FactoryBot.create(:lesson) }
@@ -78,6 +139,70 @@ describe 'Lessons' do
         )
 
         run_test!
+      end
+    end
+
+    patch('update the referenced lesson') do
+      tags('Lesson')
+
+      consumes 'application/json'
+
+      let(:lesson) { FactoryBot.create(:lesson) }
+      let(:unit) { lesson.unit }
+      let(:ccp) { unit.complete_curriculum_programme }
+      let(:unit_id) { unit.id }
+      let(:ccp_id) { ccp.id }
+      let(:id) { lesson.id }
+      let(:lesson_params) { { lesson: FactoryBot.attributes_for(:lesson) } }
+
+      parameter(name: :ccp_id, in: :path, type: :string, required: true)
+      parameter(name: :unit_id, in: :path, type: :string, required: true)
+      parameter(name: :id, in: :path, type: :string, required: true)
+
+      parameter(
+        name: :lesson_params,
+        in: :body,
+        schema: {
+          properties: {
+            lesson: {
+              type: :object,
+              properties: {
+                id: { type: :integer },
+                name: { type: :string },
+                summary: { type: :string },
+                core_knowledge: { type: :string },
+                previous_knowledge: { type: :string },
+                vocabulary: {
+                  type: :array, items: { type: :string }
+                },
+                misconceptions: {
+                  type: :array, items: { type: :string }
+                },
+              },
+              required: %i(lesson)
+            }
+          }
+        }
+      )
+
+      response(200, 'lesson updated') do
+        examples('application/json': { lesson: FactoryBot.attributes_for(:lesson) })
+
+        run_test! do |response|
+          JSON.parse(response.body).with_indifferent_access.tap do |json|
+            lesson_params.dig(:lesson).each do |attribute, value|
+              expect(json[attribute]).to eql(value)
+            end
+          end
+        end
+      end
+
+      response(400, 'invalid lesson') do
+        let(:lesson_params) { { lesson: FactoryBot.attributes_for(:lesson, name: '') } }
+
+        run_test! do |response|
+          expect(JSON.parse(response.body).dig('errors')).to include(%(Name can't be blank))
+        end
       end
     end
   end

--- a/spec/integration/api/v1/lessons_spec.rb
+++ b/spec/integration/api/v1/lessons_spec.rb
@@ -53,7 +53,6 @@ describe 'Lessons' do
       let(:unit_id) { lesson.unit.id }
       let(:id) { lesson.id }
 
-
       parameter(name: :ccp_id, in: :path, type: :string, required: true)
       parameter(name: :unit_id, in: :path, type: :string, required: true)
       parameter(name: :id, in: :path, type: :string, required: true)

--- a/spec/integration/api/v1/lessons_spec.rb
+++ b/spec/integration/api/v1/lessons_spec.rb
@@ -32,7 +32,7 @@ describe 'Lessons' do
               },
               misconceptions: {
                 type: :array, items: { type: :string }
-              },
+              }
             }
           }
         )
@@ -73,7 +73,31 @@ describe 'Lessons' do
                   type: :array, items: { type: :string }
                 },
               },
-              required: %i(unit)
+              required: %i(lesson)
+            }
+          }
+        }
+      )
+
+      request_body_json(
+        schema: {
+          properties: {
+            lesson: {
+              type: :object,
+              properties: {
+                id: { type: :integer },
+                name: { type: :string },
+                summary: { type: :string },
+                core_knowledge: { type: :string },
+                previous_knowledge: { type: :string },
+                vocabulary: {
+                  type: :array, items: { type: :string }
+                },
+                misconceptions: {
+                  type: :array, items: { type: :string }
+                },
+              },
+              required: %i(lesson)
             }
           }
         }
@@ -117,6 +141,30 @@ describe 'Lessons' do
       parameter(name: :ccp_id, in: :path, type: :string, required: true)
       parameter(name: :unit_id, in: :path, type: :string, required: true)
       parameter(name: :id, in: :path, type: :string, required: true)
+
+      request_body_json(
+        schema: {
+          properties: {
+            lesson: {
+              type: :object,
+              properties: {
+                id: { type: :integer },
+                name: { type: :string },
+                summary: { type: :string },
+                core_knowledge: { type: :string },
+                previous_knowledge: { type: :string },
+                vocabulary: {
+                  type: :array, items: { type: :string }
+                },
+                misconceptions: {
+                  type: :array, items: { type: :string }
+                },
+              },
+              required: %i(unit)
+            }
+          }
+        }
+      )
 
       response('200', 'lesson found') do
         examples('application/json': example_lesson)
@@ -162,6 +210,30 @@ describe 'Lessons' do
       parameter(
         name: :lesson_params,
         in: :body,
+        schema: {
+          properties: {
+            lesson: {
+              type: :object,
+              properties: {
+                id: { type: :integer },
+                name: { type: :string },
+                summary: { type: :string },
+                core_knowledge: { type: :string },
+                previous_knowledge: { type: :string },
+                vocabulary: {
+                  type: :array, items: { type: :string }
+                },
+                misconceptions: {
+                  type: :array, items: { type: :string }
+                },
+              },
+              required: %i(lesson)
+            }
+          }
+        }
+      )
+
+      request_body_json(
         schema: {
           properties: {
             lesson: {

--- a/spec/integration/api/v1/units_spec.rb
+++ b/spec/integration/api/v1/units_spec.rb
@@ -2,8 +2,8 @@ require 'swagger_helper'
 
 describe 'Units' do
   path('/ccps/{ccp_id}/units') do
-    get('Retrieves all units belonging to the provided CCP') do
-      tags('CCP')
+    get('retrieves all units belonging to the provided CCP') do
+      tags('Unit')
       produces('application/json')
 
       let!(:ccp) { FactoryBot.create(:ccp) }
@@ -31,11 +31,66 @@ describe 'Units' do
         run_test!
       end
     end
+
+    post('creates a new unit belonging to the specified CCP') do
+      tags('Unit')
+
+      let(:ccp) { FactoryBot.create(:ccp) }
+      let(:ccp_id) { ccp.id }
+
+      consumes 'application/json'
+
+      parameter(name: :ccp_id, in: :path, type: :string, required: true)
+
+      parameter(
+        name: :unit_params,
+        in: :body,
+        schema: {
+          properties: {
+            unit: {
+              type: :object,
+              proprties: {
+                name: { type: :string },
+                benefits: { type: :string },
+                overview: { type: :string }
+              },
+              required: %i(name benefits overview)
+            },
+            required: %i(unit)
+          }
+        }
+      )
+
+      response(201, 'unit created') do
+        let!(:unit_params) { { unit: FactoryBot.attributes_for(:unit) } }
+
+        examples('application/json': { unit: example_unit })
+
+        run_test! do |response|
+          # all of the values in the payload should be present in the returned
+          # JSON, along with some others added by saving (id, timestamps)
+
+          JSON.parse(response.body).with_indifferent_access.tap do |json|
+            unit_params.dig(:unit).each do |attribute, value|
+              expect(json[attribute]).to eql(value)
+            end
+          end
+        end
+      end
+
+      response(400, 'invalid unit') do
+        let!(:unit_params) { { unit: FactoryBot.attributes_for(:unit, name: '') } }
+
+        run_test! do |response|
+          expect(JSON.parse(response.body).dig('errors')).to include(%(Name can't be blank))
+        end
+      end
+    end
   end
 
   path('/ccps/{ccp_id}/units/{id}') do
-    get('Retrieves a single unit belonging to the specified CCP') do
-      tags('CCP')
+    get('retrieves a single unit belonging to the specified CCP') do
+      tags('Unit')
       produces('application/json')
 
       let!(:unit) { FactoryBot.create(:unit) }
@@ -93,6 +148,60 @@ describe 'Units' do
         )
 
         run_test!
+      end
+    end
+
+    patch('update the referenced unit') do
+      tags('Unit')
+
+      consumes 'application/json'
+
+      let(:ccp) { FactoryBot.create(:ccp) }
+      let(:unit) { FactoryBot.create(:unit, complete_curriculum_programme: ccp) }
+      let(:ccp_id) { ccp.id }
+      let(:id) { unit.id }
+      let(:unit_params) { { unit: FactoryBot.attributes_for(:unit) } }
+
+      parameter(name: :ccp_id, in: :path, type: :string, required: true)
+      parameter(name: :id, in: :path, type: :string, required: true)
+
+      parameter(
+        name: :unit_params,
+        in: :body,
+        schema: {
+          properties: {
+            unit: {
+              type: :object,
+              proprties: {
+                name: { type: :string },
+                benefits: { type: :string },
+                overview: { type: :string }
+              },
+              required: %i(name benefits overview)
+            },
+            required: %i(unit)
+          }
+        }
+      )
+
+      response(200, 'unit updated') do
+        examples('application/json': { unit: FactoryBot.attributes_for(:unit) })
+
+        run_test! do |response|
+          JSON.parse(response.body).with_indifferent_access.tap do |json|
+            unit_params.dig(:unit).each do |attribute, value|
+              expect(json[attribute]).to eql(value)
+            end
+          end
+        end
+      end
+
+      response(400, 'invalid unit') do
+        let(:unit_params) { { unit: FactoryBot.attributes_for(:unit, name: '') } }
+
+        run_test! do |response|
+          expect(JSON.parse(response.body).dig('errors')).to include(%(Name can't be blank))
+        end
       end
     end
   end

--- a/spec/integration/api/v1/units_spec.rb
+++ b/spec/integration/api/v1/units_spec.rb
@@ -49,7 +49,24 @@ describe 'Units' do
           properties: {
             unit: {
               type: :object,
-              proprties: {
+              properties: {
+                name: { type: :string },
+                benefits: { type: :string },
+                overview: { type: :string }
+              },
+              required: %i(name benefits overview)
+            },
+            required: %i(unit)
+          }
+        }
+      )
+
+      request_body_json(
+        schema: {
+          properties: {
+            unit: {
+              type: :object,
+              properties: {
                 name: { type: :string },
                 benefits: { type: :string },
                 overview: { type: :string }
@@ -172,7 +189,24 @@ describe 'Units' do
           properties: {
             unit: {
               type: :object,
-              proprties: {
+              properties: {
+                name: { type: :string },
+                benefits: { type: :string },
+                overview: { type: :string }
+              },
+              required: %i(name benefits overview)
+            },
+            required: %i(unit)
+          }
+        }
+      )
+
+      request_body_json(
+        schema: {
+          properties: {
+            unit: {
+              type: :object,
+              properties: {
                 name: { type: :string },
                 benefits: { type: :string },
                 overview: { type: :string }

--- a/spec/support/api_examples.rb
+++ b/spec/support/api_examples.rb
@@ -1,5 +1,5 @@
 def example_ccp(id = 1)
-  FactoryBot.attributes_for(:ccp, :randomised).merge(id: id)
+  FactoryBot.attributes_for(:ccp).merge(id: id)
 end
 
 def example_ccps(quantity)
@@ -7,7 +7,7 @@ def example_ccps(quantity)
 end
 
 def example_unit(id = 1)
-  FactoryBot.attributes_for(:unit, :randomised).merge(id: id)
+  FactoryBot.attributes_for(:unit).merge(id: id)
 end
 
 def example_units(quantity)
@@ -15,7 +15,7 @@ def example_units(quantity)
 end
 
 def example_lesson(id = 1)
-  FactoryBot.attributes_for(:lesson, :randomised).merge(id: id)
+  FactoryBot.attributes_for(:lesson).merge(id: id)
 end
 
 def example_lessons(quantity)

--- a/spec/support/api_examples.rb
+++ b/spec/support/api_examples.rb
@@ -21,3 +21,7 @@ end
 def example_lessons(quantity)
   1.upto(quantity).map { |i| example_lesson(i) }
 end
+
+def example_errors
+  ["Name can't be blank"]
+end


### PR DESCRIPTION
The initial draft of the API allowed only the retrieval of CCPs, units and lessons. Now the API supports writing them (individually, for the time being) too.

Everything has been swaggerized and the docs are available on the review app under `/api-docs`

![Screenshot_2020-02-05 Swagger UI](https://user-images.githubusercontent.com/128088/73847002-5d03c100-481d-11ea-8b08-1570866db71d.png)

