### PR TITLE
Reduce steps in log out flow

### DIFF
--- a/app/controllers/teachers/logged_out_controller.rb
+++ b/app/controllers/teachers/logged_out_controller.rb
@@ -2,6 +2,8 @@ module Teachers
   class LoggedOutController < BaseController
     skip_before_action :ensure_token_exists
 
-    def show; end
+    def show
+      @token = params[:token]
+    end
   end
 end

--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -14,12 +14,12 @@ module Teachers
       end
     end
 
-    def show; end
-
     def destroy
+      token = session[:token]
+
       session.clear
 
-      redirect_to teachers_logged_out_path
+      redirect_to teachers_logged_out_path(token: token)
     end
   end
 end

--- a/app/views/layouts/shared/_phase_banner.slim
+++ b/app/views/layouts/shared/_phase_banner.slim
@@ -9,4 +9,4 @@
 
   - if @current_teacher.present?
     div.logout
-      = link_to 'Log out', teachers_session_path, class: 'govuk-link'
+      = button_to 'Log out', teachers_session_path, method: :delete, class: 'govuk-link'

--- a/app/views/teachers/logged_out/show.slim
+++ b/app/views/teachers/logged_out/show.slim
@@ -1,3 +1,8 @@
 h1.govuk-heading-l You have logged out
 
-p To log in again use the link that was emailed to you.
+- if @token
+  p To log in again click the link below or use the link that was emailed to you.
+
+  = link_to 'Log in', create_teachers_session_path(token: @token)
+- else
+  p To log in again use the link that was emailed to you.

--- a/app/views/teachers/sessions/show.slim
+++ b/app/views/teachers/sessions/show.slim
@@ -1,8 +1,0 @@
-= back_button :back
-
-h1.govuk-heading-l Log out
-
-.govuk-inset-text
-  | To log in again, follow the link in your email invitation.
-
-= button_to 'Log out', teachers_session_path, method: 'delete', class: 'govuk-button'

--- a/app/webpacker/styles/_logout_button.scss
+++ b/app/webpacker/styles/_logout_button.scss
@@ -1,0 +1,28 @@
+.logout {
+  input[type="submit"] {
+    border: none;
+    background: none;
+    padding: 0;
+    text-decoration: underline;
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1.25;
+    color: $govuk-link-colour;
+
+    &:hover {
+      color: $govuk-link-hover-colour;
+    }
+
+    &:visited {
+      color: $govuk-link-visited-colour;
+    }
+
+    &:active {
+      color: $govuk-link-active-colour;
+    }
+
+    &:focus {
+      @extend %govuk-link:focus;
+    }
+  }
+}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -16,3 +16,4 @@ $govuk-image-url-function: frontend-image-url;
 @import "splash";
 @import "cards";
 @import "units";
+@import "logout_button";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     resource :home, only: %i(show)
     resource :splash, only: %i(show)
 
-    resource :session, only: %i(show destroy) do
+    resource :session, only: %i(destroy) do
       get '/:token', to: 'sessions#create', as: 'create'
     end
 

--- a/spec/controllers/teachers/logged_out_controller_spec.rb
+++ b/spec/controllers/teachers/logged_out_controller_spec.rb
@@ -2,10 +2,20 @@ require "rails_helper"
 
 RSpec.describe Teachers::LoggedOutController, type: :request do
   describe '#show' do
-    subject { get(teachers_logged_out_path) }
+    let(:token) { 'abc123' }
+
+    subject { get(teachers_logged_out_path(token: token)) }
 
     specify 'should render the show template' do
       expect(subject).to render_template(:show)
+    end
+
+    specify 'the page has a link to log back in' do
+      subject
+
+      page = Capybara::Node::Simple.new response.body
+
+      expect(page).to have_link 'Log in', href: "/teachers/session/#{token}"
     end
   end
 end

--- a/spec/features/teachers/logging_out_spec.rb
+++ b/spec/features/teachers/logging_out_spec.rb
@@ -6,16 +6,15 @@ RSpec.feature "Logging out", type: :feature do
 
     before { visit(teachers_home_path) }
 
-    specify 'there should be a logout link in the phase bar' do
+    specify 'there should be a logout button in the phase bar' do
       within('.govuk-phase-banner') do
-        expect(page).to have_link('Log out', href: teachers_session_path)
+        within('form[action="/teachers/session"]') do
+          expect(page).to have_button('Log out')
+        end
       end
     end
 
     specify 'actually logging out' do
-      click_link 'Log out'
-      expect(page.current_path).to eql(teachers_session_path)
-
       click_button 'Log out'
       expect(page.current_path).to eql(teachers_logged_out_path)
 


### PR DESCRIPTION
### Context
After speaking with our designer we've decided to remove a step from the
log out flow. Now clicking log out will log the teacher out straight
away.
A link to log back in has also been added to the log out page.

### Changes proposed in this pull request
Remove the intermediate sessions show page

### Guidance to review
Logging in and out should still work as before but it should now be a one step process.


[ASIDE we'll want to have a think about how to generate teacher sign in links for review apps more easily