### PR TITLE
Remove duplication from API docs by using schemas

### DIFF
--- a/app/controllers/api/v1/lessons_controller.rb
+++ b/app/controllers/api/v1/lessons_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::LessonsController < ApplicationController
+class Api::V1::LessonsController < Api::BaseController
   def index
     lessons = Lesson
       .eager_load(:unit)

--- a/app/controllers/api/v1/lessons_controller.rb
+++ b/app/controllers/api/v1/lessons_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::LessonsController < ApplicationController
   def index
     lessons = Lesson
+      .eager_load(:unit)
       .where(unit_id: params[:unit_id])
       .all
 

--- a/app/controllers/api/v1/units_controller.rb
+++ b/app/controllers/api/v1/units_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::UnitsController < ApplicationController
+class Api::V1::UnitsController < Api::BaseController
   def index
     units = Unit
       .where(complete_curriculum_programme_id: params[:ccp_id])

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -134,7 +134,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ccp"
+                "properties": {
+                  "ccp": {
+                    "$ref": "#/components/schemas/ccp"
+                  }
+                }
               }
             }
           }
@@ -229,7 +233,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ccp"
+                "properties": {
+                  "ccp": {
+                    "$ref": "#/components/schemas/ccp"
+                  }
+                }
               }
             }
           }
@@ -356,10 +364,12 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "$ref": "#/components/schemas/lesson",
-                  "required": [
-                    "lesson"
-                  ]
+                  "lesson": {
+                    "$ref": "#/components/schemas/lesson",
+                    "required": [
+                      "lesson"
+                    ]
+                  }
                 }
               }
             }
@@ -507,10 +517,12 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "$ref": "#/components/schemas/lesson",
-                  "required": [
-                    "lesson"
-                  ]
+                  "lesson": {
+                    "$ref": "#/components/schemas/lesson",
+                    "required": [
+                      "lesson"
+                    ]
+                  }
                 }
               }
             }
@@ -613,10 +625,12 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "$ref": "#/components/schemas/unit",
-                  "required": [
-                    "unit"
-                  ]
+                  "unit": {
+                    "$ref": "#/components/schemas/unit",
+                    "required": [
+                      "unit"
+                    ]
+                  }
                 }
               }
             }
@@ -768,7 +782,14 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/unit"
+                "properties": {
+                  "unit": {
+                    "$ref": "#/components/schemas/unit",
+                    "required": [
+                      "unit"
+                    ]
+                  }
+                }
               }
             }
           }
@@ -798,7 +819,7 @@
       "url": "http://{defaultHost}",
       "variables": {
         "defaultHost": {
-          "default": "localhost:3001/api/v1"
+          "default": "localhost:3000/api/v1"
         }
       }
     }

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -4,6 +4,91 @@
     "title": "API V1",
     "version": "v1"
   },
+  "components": {
+    "schemas": {
+      "ccp": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "benefits": {
+            "type": "string"
+          },
+          "overview": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "benefits",
+          "overview"
+        ]
+      },
+      "unit": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "benefits": {
+            "type": "string"
+          },
+          "overview": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "benefits",
+          "overview"
+        ]
+      },
+      "lesson": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "core_knowledge": {
+            "type": "string"
+          },
+          "previous_knowledge": {
+            "type": "string"
+          },
+          "vocabulary": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "misconceptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "summary",
+          "core_knowledge",
+          "previous_knowledge",
+          "vocabulary",
+          "misconceptions"
+        ]
+      }
+    }
+  },
   "basePath": "/api/v1",
   "paths": {
     "/ccps": {
@@ -16,35 +101,19 @@
           "200": {
             "description": "ccps found",
             "examples": {
-              "application/json": [
-                {
-                  "name": "CCP 1",
-                  "overview": "Overview",
-                  "benefits": "Benefits",
-                  "id": 1
-                }
-              ]
+              "application/json": {
+                "name": "CCP 1",
+                "overview": "Overview",
+                "benefits": "Benefits",
+                "id": 1
+              }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "integer"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "benefits": {
-                        "type": "string"
-                      },
-                      "overview": {
-                        "type": "string"
-                      }
-                    }
+                    "$ref": "#/components/schemas/ccp"
                   }
                 }
               }
@@ -65,30 +134,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "properties": {
-                  "ccp": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "benefits": {
-                        "type": "string"
-                      },
-                      "overview": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "benefits",
-                      "overview"
-                    ]
-                  },
-                  "required": [
-                    "ccp"
-                  ]
-                }
+                "$ref": "#/components/schemas/ccp"
               }
             }
           }
@@ -156,41 +202,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "benefits": {
-                      "type": "string"
-                    },
-                    "overview": {
-                      "type": "string"
-                    },
-                    "units": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "benefits": {
-                            "type": "string"
-                          },
-                          "overview": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/ccp"
                 }
               }
             }
@@ -217,30 +229,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "properties": {
-                  "ccp": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "benefits": {
-                        "type": "string"
-                      },
-                      "overview": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "benefits",
-                      "overview"
-                    ]
-                  },
-                  "required": [
-                    "ccp"
-                  ]
-                }
+                "$ref": "#/components/schemas/ccp"
               }
             }
           }
@@ -293,38 +282,36 @@
             "description": "lessons found",
             "examples": {
               "application/json": [
-                [
-                  {
-                    "name": "Lesson 1",
-                    "summary": "Lesson 1",
-                    "core_knowledge": "Core knowledge",
-                    "previous_knowledge": "Previous knowledge",
-                    "vocabulary": [
-                      "Subtraction",
-                      "Division",
-                      "Multiplication"
-                    ],
-                    "misconceptions": [
-                      "Fractions are not natural numbers"
-                    ],
-                    "id": 1
-                  },
-                  {
-                    "name": "Lesson 2",
-                    "summary": "Lesson 2",
-                    "core_knowledge": "Core knowledge",
-                    "previous_knowledge": "Previous knowledge",
-                    "vocabulary": [
-                      "Subtraction",
-                      "Division",
-                      "Multiplication"
-                    ],
-                    "misconceptions": [
-                      "Fractions are not natural numbers"
-                    ],
-                    "id": 2
-                  }
-                ]
+                {
+                  "name": "Lesson 1",
+                  "summary": "Lesson 1",
+                  "core_knowledge": "Core knowledge",
+                  "previous_knowledge": "Previous knowledge",
+                  "vocabulary": [
+                    "Subtraction",
+                    "Division",
+                    "Multiplication"
+                  ],
+                  "misconceptions": [
+                    "Fractions are not natural numbers"
+                  ],
+                  "id": 1
+                },
+                {
+                  "name": "Lesson 2",
+                  "summary": "Lesson 2",
+                  "core_knowledge": "Core knowledge",
+                  "previous_knowledge": "Previous knowledge",
+                  "vocabulary": [
+                    "Subtraction",
+                    "Division",
+                    "Multiplication"
+                  ],
+                  "misconceptions": [
+                    "Fractions are not natural numbers"
+                  ],
+                  "id": 2
+                }
               ]
             },
             "content": {
@@ -332,36 +319,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "integer"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "summary": {
-                        "type": "string"
-                      },
-                      "core_knowledge": {
-                        "type": "string"
-                      },
-                      "previous_knowledge": {
-                        "type": "string"
-                      },
-                      "vocabulary": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "misconceptions": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
+                    "$ref": "#/components/schemas/lesson"
                   }
                 }
               }
@@ -398,41 +356,10 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "lesson": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "integer"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "summary": {
-                        "type": "string"
-                      },
-                      "core_knowledge": {
-                        "type": "string"
-                      },
-                      "previous_knowledge": {
-                        "type": "string"
-                      },
-                      "vocabulary": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "misconceptions": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "required": [
-                      "lesson"
-                    ]
-                  }
+                  "$ref": "#/components/schemas/lesson",
+                  "required": [
+                    "lesson"
+                  ]
                 }
               }
             }
@@ -504,41 +431,10 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "lesson": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "integer"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "summary": {
-                        "type": "string"
-                      },
-                      "core_knowledge": {
-                        "type": "string"
-                      },
-                      "previous_knowledge": {
-                        "type": "string"
-                      },
-                      "vocabulary": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "misconceptions": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "required": [
-                      "unit"
-                    ]
-                  }
+                  "$ref": "#/components/schemas/lesson",
+                  "required": [
+                    "lesson"
+                  ]
                 }
               }
             }
@@ -567,36 +463,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "summary": {
-                      "type": "string"
-                    },
-                    "core_knowledge": {
-                      "type": "string"
-                    },
-                    "previous_knowledge": {
-                      "type": "string"
-                    },
-                    "vocabulary": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "misconceptions": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/lesson"
                 }
               }
             }
@@ -640,41 +507,10 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "lesson": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "integer"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "summary": {
-                        "type": "string"
-                      },
-                      "core_knowledge": {
-                        "type": "string"
-                      },
-                      "previous_knowledge": {
-                        "type": "string"
-                      },
-                      "vocabulary": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "misconceptions": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "required": [
-                      "lesson"
-                    ]
-                  }
+                  "$ref": "#/components/schemas/lesson",
+                  "required": [
+                    "lesson"
+                  ]
                 }
               }
             }
@@ -729,20 +565,18 @@
             "description": "units found",
             "examples": {
               "application/json": [
-                [
-                  {
-                    "name": "Unit 3",
-                    "overview": "Overview",
-                    "benefits": "Benefits",
-                    "id": 1
-                  },
-                  {
-                    "name": "Unit 4",
-                    "overview": "Overview",
-                    "benefits": "Benefits",
-                    "id": 2
-                  }
-                ]
+                {
+                  "name": "Unit 3",
+                  "overview": "Overview",
+                  "benefits": "Benefits",
+                  "id": 1
+                },
+                {
+                  "name": "Unit 4",
+                  "overview": "Overview",
+                  "benefits": "Benefits",
+                  "id": 2
+                }
               ]
             },
             "content": {
@@ -750,21 +584,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "integer"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "benefits": {
-                        "type": "string"
-                      },
-                      "overview": {
-                        "type": "string"
-                      }
-                    }
+                    "$ref": "#/components/schemas/unit"
                   }
                 }
               }
@@ -793,25 +613,7 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "unit": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "benefits": {
-                        "type": "string"
-                      },
-                      "overview": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "benefits",
-                      "overview"
-                    ]
-                  },
+                  "$ref": "#/components/schemas/unit",
                   "required": [
                     "unit"
                   ]
@@ -931,73 +733,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "benefits": {
-                      "type": "string"
-                    },
-                    "overview": {
-                      "type": "string"
-                    },
-                    "complete_curriculum_programme": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "integer"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "benefits": {
-                          "type": "string"
-                        },
-                        "overview": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "lessons": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "integer"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "summary": {
-                            "type": "string"
-                          },
-                          "core_knowledge": {
-                            "type": "string"
-                          },
-                          "previous_knowledge": {
-                            "type": "string"
-                          },
-                          "vocabulary": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          "misconceptions": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/unit"
                 }
               }
             }
@@ -1032,30 +768,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "properties": {
-                  "unit": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "benefits": {
-                        "type": "string"
-                      },
-                      "overview": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "benefits",
-                      "overview"
-                    ]
-                  },
-                  "required": [
-                    "unit"
-                  ]
-                }
+                "$ref": "#/components/schemas/unit"
               }
             }
           }

--- a/spec/integration/api/v1/complete_curriculum_programmes_spec.rb
+++ b/spec/integration/api/v1/complete_curriculum_programmes_spec.rb
@@ -24,7 +24,15 @@ describe 'Complete curriculum programmes' do
 
       consumes 'application/json'
 
-      parameter(name: :ccp_params, in: :body, schema: { '$ref' => '#/components/schemas/ccp' })
+      parameter(
+        name: :ccp_params,
+        in: :body,
+        schema: {
+          properties: {
+            ccp: { '$ref' => '#/components/schemas/ccp' }
+          }
+        }
+      )
 
       request_body_json(schema: { '$ref' => '#/components/schemas/ccp' })
 
@@ -83,7 +91,15 @@ describe 'Complete curriculum programmes' do
       let(:ccp_params) { { ccp: FactoryBot.attributes_for(:ccp) } }
 
       parameter(name: :id, in: :path, type: :string, required: true)
-      parameter(name: :ccp_params, in: :body, schema: { '$ref' => '#/components/schemas/ccp' })
+      parameter(
+        name: :ccp_params,
+        in: :body,
+        schema: {
+          properties: {
+            ccp: { '$ref' => '#/components/schemas/ccp' }
+          }
+        }
+      )
 
       request_body_json(schema: { '$ref' => '#/components/schemas/ccp' })
 

--- a/spec/integration/api/v1/complete_curriculum_programmes_spec.rb
+++ b/spec/integration/api/v1/complete_curriculum_programmes_spec.rb
@@ -10,21 +10,10 @@ describe 'Complete curriculum programmes' do
 
       response 200, 'ccps found' do
         examples(
-          'application/json': [example_ccp]
+          'application/json': example_ccp
         )
 
-        schema(
-          type: :array,
-          items: {
-            type: :object,
-            properties: {
-              id: { type: :integer },
-              name: { type: :string },
-              benefits: { type: :string },
-              overview: { type: :string },
-            }
-          }
-        )
+        schema(type: :array, items: { '$ref' => '#/components/schemas/ccp' })
 
         run_test!
       end
@@ -35,41 +24,9 @@ describe 'Complete curriculum programmes' do
 
       consumes 'application/json'
 
-      parameter(
-        name: :ccp_params,
-        in: :body,
-        schema: {
-          properties: {
-            ccp: {
-              type: :object,
-              properties: {
-                name: { type: :string },
-                benefits: { type: :string },
-                overview: { type: :string }
-              },
-              required: %i(name benefits overview)
-            },
-            required: %i(ccp)
-          }
-        }
-      )
+      parameter(name: :ccp_params, in: :body, schema: { '$ref' => '#/components/schemas/ccp' })
 
-      request_body_json(
-        schema: {
-          properties: {
-            ccp: {
-              type: :object,
-              properties: {
-                name: { type: :string },
-                benefits: { type: :string },
-                overview: { type: :string }
-              },
-              required: %i(name benefits overview)
-            },
-            required: %i(ccp)
-          }
-        }
-      )
+      request_body_json(schema: { '$ref' => '#/components/schemas/ccp' })
 
       response(201, 'ccp created') do
         let!(:ccp_params) { { ccp: FactoryBot.attributes_for(:ccp) } }
@@ -111,29 +68,7 @@ describe 'Complete curriculum programmes' do
       response(200, 'ccp found') do
         examples('application/json': example_ccp.merge(units: example_units(2)))
 
-        schema(
-          type: :object,
-          properties: {
-            id: { type: :integer },
-            name: { type: :string },
-            benefits: { type: :string },
-            overview: { type: :string },
-
-            # retrieving a single CCP also returns its units
-            units: {
-              type: :array,
-              items: {
-                type: :object,
-                properties: {
-                  id: { type: :integer },
-                  name: { type: :string },
-                  benefits: { type: :string },
-                  overview: { type: :string }
-                }
-              }
-            }
-          }
-        )
+        schema('$ref' => '#/components/schemas/ccp')
 
         run_test!
       end
@@ -148,42 +83,9 @@ describe 'Complete curriculum programmes' do
       let(:ccp_params) { { ccp: FactoryBot.attributes_for(:ccp) } }
 
       parameter(name: :id, in: :path, type: :string, required: true)
+      parameter(name: :ccp_params, in: :body, schema: { '$ref' => '#/components/schemas/ccp' })
 
-      parameter(
-        name: :ccp_params,
-        in: :body,
-        schema: {
-          properties: {
-            ccp: {
-              type: :object,
-              properties: {
-                name: { type: :string },
-                benefits: { type: :string },
-                overview: { type: :string }
-              },
-              required: %i(name benefits overview)
-            },
-            required: %i(ccp)
-          }
-        }
-      )
-
-      request_body_json(
-        schema: {
-          properties: {
-            ccp: {
-              type: :object,
-              properties: {
-                name: { type: :string },
-                benefits: { type: :string },
-                overview: { type: :string }
-              },
-              required: %i(name benefits overview)
-            },
-            required: %i(ccp)
-          }
-        }
-      )
+      request_body_json(schema: { '$ref' => '#/components/schemas/ccp' })
 
       response(200, 'ccp updated') do
         examples('application/json': { ccp: FactoryBot.attributes_for(:ccp) })

--- a/spec/integration/api/v1/lessons_spec.rb
+++ b/spec/integration/api/v1/lessons_spec.rb
@@ -15,27 +15,9 @@ describe 'Lessons' do
       parameter(name: :unit_id, in: :path, type: :string, required: true)
 
       response '200', 'lessons found' do
-        examples('application/json': [example_lessons(2)])
+        examples('application/json': example_lessons(2))
 
-        schema(
-          type: :array,
-          items: {
-            type: :object,
-            properties: {
-              id: { type: :integer },
-              name: { type: :string },
-              summary: { type: :string },
-              core_knowledge: { type: :string },
-              previous_knowledge: { type: :string },
-              vocabulary: {
-                type: :array, items: { type: :string }
-              },
-              misconceptions: {
-                type: :array, items: { type: :string }
-              }
-            }
-          }
-        )
+        schema(type: :array, items: { '$ref' => '#/components/schemas/lesson' })
 
         run_test!
       end
@@ -52,54 +34,17 @@ describe 'Lessons' do
 
       parameter(name: :ccp_id, in: :path, type: :string, required: true)
       parameter(name: :unit_id, in: :path, type: :string, required: true)
-
       parameter(
         name: :lesson_params,
         in: :body,
         schema: {
-          properties: {
-            lesson: {
-              type: :object,
-              properties: {
-                id: { type: :integer },
-                name: { type: :string },
-                summary: { type: :string },
-                core_knowledge: { type: :string },
-                previous_knowledge: { type: :string },
-                vocabulary: {
-                  type: :array, items: { type: :string }
-                },
-                misconceptions: {
-                  type: :array, items: { type: :string }
-                },
-              },
-              required: %i(lesson)
-            }
-          }
+          properties: { '$ref' => '#/components/schemas/lesson', required: %i(lesson) }
         }
       )
 
       request_body_json(
         schema: {
-          properties: {
-            lesson: {
-              type: :object,
-              properties: {
-                id: { type: :integer },
-                name: { type: :string },
-                summary: { type: :string },
-                core_knowledge: { type: :string },
-                previous_knowledge: { type: :string },
-                vocabulary: {
-                  type: :array, items: { type: :string }
-                },
-                misconceptions: {
-                  type: :array, items: { type: :string }
-                },
-              },
-              required: %i(lesson)
-            }
-          }
+          properties: { '$ref' => '#/components/schemas/lesson', required: %i(lesson) }
         }
       )
 
@@ -144,47 +89,14 @@ describe 'Lessons' do
 
       request_body_json(
         schema: {
-          properties: {
-            lesson: {
-              type: :object,
-              properties: {
-                id: { type: :integer },
-                name: { type: :string },
-                summary: { type: :string },
-                core_knowledge: { type: :string },
-                previous_knowledge: { type: :string },
-                vocabulary: {
-                  type: :array, items: { type: :string }
-                },
-                misconceptions: {
-                  type: :array, items: { type: :string }
-                },
-              },
-              required: %i(unit)
-            }
-          }
+          properties: { '$ref' => '#/components/schemas/lesson', required: %i(lesson) }
         }
       )
 
       response('200', 'lesson found') do
         examples('application/json': example_lesson)
 
-        schema(
-          type: :object,
-          properties: {
-            id: { type: :integer },
-            name: { type: :string },
-            summary: { type: :string },
-            core_knowledge: { type: :string },
-            previous_knowledge: { type: :string },
-            vocabulary: {
-              type: :array, items: { type: :string }
-            },
-            misconceptions: {
-              type: :array, items: { type: :string }
-            }
-          }
-        )
+        schema('$ref' => '#/components/schemas/lesson')
 
         run_test!
       end
@@ -206,56 +118,15 @@ describe 'Lessons' do
       parameter(name: :ccp_id, in: :path, type: :string, required: true)
       parameter(name: :unit_id, in: :path, type: :string, required: true)
       parameter(name: :id, in: :path, type: :string, required: true)
-
       parameter(
         name: :lesson_params,
         in: :body,
         schema: {
-          properties: {
-            lesson: {
-              type: :object,
-              properties: {
-                id: { type: :integer },
-                name: { type: :string },
-                summary: { type: :string },
-                core_knowledge: { type: :string },
-                previous_knowledge: { type: :string },
-                vocabulary: {
-                  type: :array, items: { type: :string }
-                },
-                misconceptions: {
-                  type: :array, items: { type: :string }
-                },
-              },
-              required: %i(lesson)
-            }
-          }
+          properties: { '$ref' => '#/components/schemas/lesson', required: %i(lesson) }
         }
       )
 
-      request_body_json(
-        schema: {
-          properties: {
-            lesson: {
-              type: :object,
-              properties: {
-                id: { type: :integer },
-                name: { type: :string },
-                summary: { type: :string },
-                core_knowledge: { type: :string },
-                previous_knowledge: { type: :string },
-                vocabulary: {
-                  type: :array, items: { type: :string }
-                },
-                misconceptions: {
-                  type: :array, items: { type: :string }
-                },
-              },
-              required: %i(lesson)
-            }
-          }
-        }
-      )
+      request_body_json(schema: { '$ref' => '#/components/schemas/lesson' })
 
       response(200, 'lesson updated') do
         examples('application/json': { lesson: FactoryBot.attributes_for(:lesson) })

--- a/spec/integration/api/v1/lessons_spec.rb
+++ b/spec/integration/api/v1/lessons_spec.rb
@@ -38,7 +38,11 @@ describe 'Lessons' do
         name: :lesson_params,
         in: :body,
         schema: {
-          properties: { '$ref' => '#/components/schemas/lesson', required: %i(lesson) }
+          properties: { 
+            lesson: {
+              '$ref' => '#/components/schemas/lesson', required: %i(lesson)
+            }
+          }
         }
       )
 
@@ -122,7 +126,11 @@ describe 'Lessons' do
         name: :lesson_params,
         in: :body,
         schema: {
-          properties: { '$ref' => '#/components/schemas/lesson', required: %i(lesson) }
+          properties: { 
+            lesson: {
+              '$ref' => '#/components/schemas/lesson', required: %i(lesson)
+            }
+          }
         }
       )
 

--- a/spec/integration/api/v1/units_spec.rb
+++ b/spec/integration/api/v1/units_spec.rb
@@ -13,20 +13,9 @@ describe 'Units' do
       parameter(name: :ccp_id, in: :path, type: :string, required: true)
 
       response '200', 'units found' do
-        examples('application/json': [example_units(2)])
+        examples('application/json': example_units(2))
 
-        schema(
-          type: :array,
-          items: {
-            type: :object,
-            properties: {
-              id: { type: :integer },
-              name: { type: :string },
-              benefits: { type: :string },
-              overview: { type: :string },
-            }
-          }
-        )
+        schema(type: :array, items: { '$ref' => '#/components/schemas/unit' })
 
         run_test!
       end
@@ -46,35 +35,13 @@ describe 'Units' do
         name: :unit_params,
         in: :body,
         schema: {
-          properties: {
-            unit: {
-              type: :object,
-              properties: {
-                name: { type: :string },
-                benefits: { type: :string },
-                overview: { type: :string }
-              },
-              required: %i(name benefits overview)
-            },
-            required: %i(unit)
-          }
+          properties: { '$ref' => '#/components/schemas/unit', required: %i(unit) }
         }
       )
 
       request_body_json(
         schema: {
-          properties: {
-            unit: {
-              type: :object,
-              properties: {
-                name: { type: :string },
-                benefits: { type: :string },
-                overview: { type: :string }
-              },
-              required: %i(name benefits overview)
-            },
-            required: %i(unit)
-          }
+          properties: { '$ref' => '#/components/schemas/unit', required: %i(unit) }
         }
       )
 
@@ -126,43 +93,7 @@ describe 'Units' do
           )
         )
 
-        schema(
-          type: :object,
-          properties: {
-            id: { type: :integer },
-            name: { type: :string },
-            benefits: { type: :string },
-            overview: { type: :string },
-            complete_curriculum_programme: {
-              type: :object,
-              properties: {
-                id: { type: :integer },
-                name: { type: :string },
-                benefits: { type: :string },
-                overview: { type: :string }
-              }
-            },
-            lessons: {
-              type: :array,
-              items: {
-                type: :object,
-                properties: {
-                  id: { type: :integer },
-                  name: { type: :string },
-                  summary: { type: :string },
-                  core_knowledge: { type: :string },
-                  previous_knowledge: { type: :string },
-                  vocabulary: {
-                    type: :array, items: { type: :string }
-                  },
-                  misconceptions: {
-                    type: :array, items: { type: :string }
-                  },
-                }
-              }
-            }
-          }
-        )
+        schema('$ref' => '#/components/schemas/unit')
 
         run_test!
       end
@@ -181,42 +112,9 @@ describe 'Units' do
 
       parameter(name: :ccp_id, in: :path, type: :string, required: true)
       parameter(name: :id, in: :path, type: :string, required: true)
+      parameter(name: :unit_params, in: :body, schema: { '$ref' => '#/components/schemas/unit' })
 
-      parameter(
-        name: :unit_params,
-        in: :body,
-        schema: {
-          properties: {
-            unit: {
-              type: :object,
-              properties: {
-                name: { type: :string },
-                benefits: { type: :string },
-                overview: { type: :string }
-              },
-              required: %i(name benefits overview)
-            },
-            required: %i(unit)
-          }
-        }
-      )
-
-      request_body_json(
-        schema: {
-          properties: {
-            unit: {
-              type: :object,
-              properties: {
-                name: { type: :string },
-                benefits: { type: :string },
-                overview: { type: :string }
-              },
-              required: %i(name benefits overview)
-            },
-            required: %i(unit)
-          }
-        }
-      )
+      request_body_json(schema: { '$ref' => '#/components/schemas/unit' })
 
       response(200, 'unit updated') do
         examples('application/json': { unit: FactoryBot.attributes_for(:unit) })

--- a/spec/integration/api/v1/units_spec.rb
+++ b/spec/integration/api/v1/units_spec.rb
@@ -34,7 +34,7 @@ describe 'Units' do
         name: :unit_params,
         in: :body,
         schema: {
-          properties: { 
+          properties: {
             unit: {
               '$ref' => '#/components/schemas/unit', required: %i(unit)
             }

--- a/spec/integration/api/v1/units_spec.rb
+++ b/spec/integration/api/v1/units_spec.rb
@@ -30,12 +30,15 @@ describe 'Units' do
       consumes 'application/json'
 
       parameter(name: :ccp_id, in: :path, type: :string, required: true)
-
       parameter(
         name: :unit_params,
         in: :body,
         schema: {
-          properties: { '$ref' => '#/components/schemas/unit', required: %i(unit) }
+          properties: { 
+            unit: {
+              '$ref' => '#/components/schemas/unit', required: %i(unit)
+            }
+          }
         }
       )
 
@@ -112,7 +115,17 @@ describe 'Units' do
 
       parameter(name: :ccp_id, in: :path, type: :string, required: true)
       parameter(name: :id, in: :path, type: :string, required: true)
-      parameter(name: :unit_params, in: :body, schema: { '$ref' => '#/components/schemas/unit' })
+      parameter(
+        name: :unit_params,
+        in: :body,
+        schema: {
+          properties: { 
+            unit: {
+              '$ref' => '#/components/schemas/unit', required: %i(unit)
+            }
+          }
+        }
+      )
 
       request_body_json(schema: { '$ref' => '#/components/schemas/unit' })
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -19,6 +19,46 @@ RSpec.configure do |config|
         title: 'API V1',
         version: 'v1'
       },
+      components: {
+        schemas: {
+          ccp: {
+            type: :object,
+            properties: {
+              id: { type: :integer },
+              name: { type: :string },
+              benefits: { type: :string },
+              overview: { type: :string },
+            },
+            required: %i(name benefits overview)
+          },
+          unit: {
+            type: :object,
+            properties: {
+              name: { type: :string },
+              benefits: { type: :string },
+              overview: { type: :string }
+            },
+            required: %i(name benefits overview)
+          },
+          lesson: {
+            type: :object,
+            properties: {
+              id: { type: :integer },
+              name: { type: :string },
+              summary: { type: :string },
+              core_knowledge: { type: :string },
+              previous_knowledge: { type: :string },
+              vocabulary: {
+                type: :array, items: { type: :string }
+              },
+              misconceptions: {
+                type: :array, items: { type: :string }
+              },
+            },
+            required: %i(name summary core_knowledge previous_knowledge vocabulary misconceptions)
+          }
+        }
+      },
       basePath: '/api/v1',
       paths: {},
       servers: [

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -66,7 +66,7 @@ RSpec.configure do |config|
           url: 'http://{defaultHost}',
           variables: {
             defaultHost: {
-              default: 'localhost:3001/api/v1'
+              default: 'localhost:3000/api/v1'
             }
           }
         }


### PR DESCRIPTION
RSwag supports OpenAPI 3.0's [data types](https://swagger.io/docs/specification/data-models/) which allow us to define each object type once and reference it internally.