### PR TITLE
Replace docker staging build with dev build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,15 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | \
       yarn
 
 RUN mkdir /usr/src/app
+
 WORKDIR /usr/src/app
 
-# Install NPM packages removing artifacts
 COPY package.json yarn.lock /usr/src/app/
-RUN yarn install && yarn cache clean
-
 COPY .ruby-version Gemfile Gemfile.lock /usr/src/app/
-
+RUN yarn install --check-files
 ENV BUNDLE_PATH /gems
-RUN bundle install --without test development
+RUN bundle install
 
 COPY . /usr/src/app/
-RUN RAILS_ENV=staging bundle exec rake assets:precompile SECRET_KEY_BASE=stubbed
 
 CMD ["bin/rails", "s", "-b", "0.0.0.0"]

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,11 +7,25 @@ default: &default
 
 development:
   <<: *default
+  <% if ENV['DB_HOST'] %>
+  host: <%= ENV['DB_HOST'] %>
+  database: <%= ENV['DB_DATABASE'] %>_development
+  username: <%= ENV['DB_USERNAME'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
+  <% else %>
   database: curriculum_materials_development
+  <% end %>
 
 test:
   <<: *default
+  <% if ENV['DB_HOST'] %>
+  host: <%= ENV['DB_HOST'] %>
+  database: <%= ENV['DB_DATABASE'] %>_test
+  username: <%= ENV['DB_USERNAME'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
+  <% else %>
   database: curriculum_materials_test
+  <% end %>
 
 production: &production
   <<: *default

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -92,3 +92,4 @@ staging:
 
 review:
   <<: *production
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,26 +5,25 @@ services:
     image: curriculum_materials:latest
     ports:
       - "3000:3000"
-    restart: always
     environment:
-      - RAILS_ENV=staging
+      - RAILS_ENV=development
       - SECRET_KEY_BASE=stubbed
-      - HTTP_AUTH_USER=test
-      - HTTP_AUTH_PASSWORD=test
-      - RAILS_SERVE_STATIC_FILES=true
       - DB_HOST=database
       - DB_DATABASE=curriculum_materials
       - DB_USERNAME=postgres
       - DB_PASSWORD=secret
+    volumes:
+      - .:/usr/src/app
+      - node_modules:/usr/src/app/node_modules
     depends_on:
       - db_tasks
 
   db_tasks:
     image: curriculum_materials:latest
     command: bundle exec rake db:create db:schema:load db:seed
-    restart: on-failure
     environment:
-      - RAILS_ENV=staging
+      - KNOWN_TEACHER_UUID=11111111-1111-1111-1111-111111111111
+      - RAILS_ENV=development
       - SECRET_KEY_BASE=stubbed
       - DB_HOST=database
       - DB_DATABASE=curriculum_materials
@@ -35,8 +34,13 @@ services:
 
   database:
     image: postgres
-    restart: on-failure
     environment:
       - POSTGRES_DB=curriculum_materials
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=secret
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+volumes:
+  db_data:
+  node_modules:


### PR DESCRIPTION
This will be more useful for the team than a staging build and will also
give us more time to decide what we want in the staging build.

Testing:
Build the image
`docker build . -t curriculum_materials:latest`
Run docker compose
`docker-compose up`

Visit
`localhost:3000/teachers/session/11111111-1111-1111-1111-111111111111`
To sign in as the teacher created in the seeds.

You should be able to edit the app and have code changes picked up by
docker.