### PR TITLE
Add activity choice model

### DIFF
--- a/app/models/activity_choice.rb
+++ b/app/models/activity_choice.rb
@@ -1,0 +1,8 @@
+class ActivityChoice < ApplicationRecord
+  belongs_to :teacher
+  belongs_to :activity
+  belongs_to :lesson_part
+
+  validates :teacher, :activity, :lesson_part, presence: true
+  validates :teacher_id, uniqueness: { scope: %i(activity_id lesson_part_id) }
+end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -2,4 +2,7 @@ class Teacher < ApplicationRecord
   validates :token,
             presence: true,
             uniqueness: { case_sensitive: false }
+
+  has_many :activity_choices, dependent: :destroy
+  has_many :activities, through: :activity_choices
 end

--- a/db/migrate/20200207140945_create_lesson_parts.rb
+++ b/db/migrate/20200207140945_create_lesson_parts.rb
@@ -3,6 +3,8 @@ class CreateLessonParts < ActiveRecord::Migration[6.0]
     create_table :lesson_parts do |t|
       t.belongs_to :lesson, null: false
       t.integer :position, null: false
+
+      t.timestamps
     end
   end
 end

--- a/db/migrate/20200207154537_add_constraint_to_lesson_part_position.rb
+++ b/db/migrate/20200207154537_add_constraint_to_lesson_part_position.rb
@@ -1,7 +1,7 @@
 class AddConstraintToLessonPartPosition < ActiveRecord::Migration[6.0]
   def change
     safety_assured do
-      add_index :lesson_parts, [:position, :lesson_id], unique: true
+      add_index :lesson_parts, %i(position lesson_id), unique: true
     end
   end
 end

--- a/db/migrate/20200212080617_create_activity_choices.rb
+++ b/db/migrate/20200212080617_create_activity_choices.rb
@@ -1,0 +1,16 @@
+class CreateActivityChoices < ActiveRecord::Migration[6.0]
+  def change
+    create_table :activity_choices do |t|
+      t.belongs_to :teacher, null: false, foreign_key: true
+      t.belongs_to :activity, null: false, foreign_key: true
+      t.belongs_to :lesson_part, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :activity_choices,
+              %i(activity_id teacher_id lesson_part_id),
+              unique: true,
+              name: 'index_activity_choices_activity_teacher_lesson_part_ids'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_11_134535) do
+ActiveRecord::Schema.define(version: 2020_02_12_080617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -24,6 +24,18 @@ ActiveRecord::Schema.define(version: 2020_02_11_134535) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["lesson_part_id"], name: "index_activities_on_lesson_part_id"
+  end
+
+  create_table "activity_choices", force: :cascade do |t|
+    t.bigint "teacher_id", null: false
+    t.bigint "activity_id", null: false
+    t.bigint "lesson_part_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["activity_id", "teacher_id", "lesson_part_id"], name: "index_activity_choices_activity_teacher_lesson_part_ids", unique: true
+    t.index ["activity_id"], name: "index_activity_choices_on_activity_id"
+    t.index ["lesson_part_id"], name: "index_activity_choices_on_lesson_part_id"
+    t.index ["teacher_id"], name: "index_activity_choices_on_teacher_id"
   end
 
   create_table "activity_teaching_methods", force: :cascade do |t|
@@ -93,6 +105,9 @@ ActiveRecord::Schema.define(version: 2020_02_11_134535) do
   end
 
   add_foreign_key "activities", "lesson_parts"
+  add_foreign_key "activity_choices", "activities"
+  add_foreign_key "activity_choices", "lesson_parts"
+  add_foreign_key "activity_choices", "teachers"
   add_foreign_key "activity_teaching_methods", "activities"
   add_foreign_key "activity_teaching_methods", "teaching_methods"
   add_foreign_key "lessons", "units"

--- a/spec/factories/activity_choices.rb
+++ b/spec/factories/activity_choices.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :activity_choice do
+    association :teacher, factory: :teacher
+    association :activity, factory: :activity
+    association :lesson_part, factory: :lesson_part
+  end
+end

--- a/spec/models/activity_choice_spec.rb
+++ b/spec/models/activity_choice_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe ActivityChoice, type: :model do
+  describe 'columns' do
+    it { is_expected.to have_db_column :teacher_id }
+    it { is_expected.to have_db_column :activity_id }
+    it { is_expected.to have_db_column :lesson_part_id }
+  end
+
+  describe 'relationships' do
+    it { is_expected.to belong_to :teacher }
+    it { is_expected.to belong_to :activity }
+    it { is_expected.to belong_to :lesson_part }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of :teacher }
+    it { is_expected.to validate_presence_of :activity }
+    it { is_expected.to validate_presence_of :lesson_part }
+
+    it do
+      expect(create(:activity_choice)).to \
+        validate_uniqueness_of(:teacher_id).scoped_to \
+          :activity_id, :lesson_part_id
+    end
+  end
+end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -16,4 +16,9 @@ RSpec.describe Teacher, type: :model do
       end
     end
   end
+
+  describe 'Relationships' do
+    it { is_expected.to have_many :activity_choices }
+    it { is_expected.to have_many(:activities).through :activity_choices }
+  end
 end


### PR DESCRIPTION
### Context
We want a way to associate teachers with the activities they have chosen for a given lesson part.
Teachers should only be able to chose one activity for a lesson part.

### Changes proposed in this pull request
Adds the activity choice model and it's associations.

### Guidance to review
Relationships and validations should look sensible.
