### PR TITLE
Add lesson part and activity api functionality

### DIFF
--- a/app/controllers/api/v1/lesson_parts_controller.rb
+++ b/app/controllers/api/v1/lesson_parts_controller.rb
@@ -34,6 +34,13 @@ class Api::V1::LessonPartsController < Api::BaseController
   end
 
   def update
+    lesson_part = LessonPart.find_by!(lesson_id: params[:lesson_id], id: params[:id])
+
+    if lesson_part.update(lesson_part_params)
+      render(json: serialize(lesson_part).to_json, status: :ok)
+    else
+      render(json: { errors: lesson_part.errors.full_messages }, status: :bad_request)
+    end
   end
 
 private
@@ -41,7 +48,6 @@ private
   def lesson_part_params
     params.require(:lesson_part).permit(:position)
   end
-
 
   def serialize(lesson_part)
     SimpleAMS::Renderer.new(

--- a/app/controllers/api/v1/lesson_parts_controller.rb
+++ b/app/controllers/api/v1/lesson_parts_controller.rb
@@ -14,6 +14,12 @@ class Api::V1::LessonPartsController < Api::BaseController
   end
 
   def show
+    lesson_part = LessonPart
+      .eager_load(:lesson)
+      .where(lesson_id: params[:lesson_id])
+      .find(params[:id])
+
+    render(json: serialize(lesson_part).to_json)
   end
 
   def create

--- a/app/controllers/api/v1/lesson_parts_controller.rb
+++ b/app/controllers/api/v1/lesson_parts_controller.rb
@@ -12,4 +12,35 @@ class Api::V1::LessonPartsController < Api::BaseController
       ).to_json
     )
   end
+
+  def show
+  end
+
+  def create
+    lesson = Lesson.find_by!(unit_id: params[:unit_id], id: params[:lesson_id])
+    lesson_part = lesson.lesson_parts.new(lesson_part_params)
+
+    if lesson_part.save
+      render(json: serialize(lesson_part).to_json, status: :created)
+    else
+      render(json: { errors: lesson_part.errors.full_messages }, status: :bad_request)
+    end
+  end
+
+  def update
+  end
+
+private
+
+  def lesson_part_params
+    params.require(:lesson_part).permit(:position)
+  end
+
+
+  def serialize(lesson_part)
+    SimpleAMS::Renderer.new(
+      lesson_part,
+      serializer: LessonPartSerializer
+    )
+  end
 end

--- a/app/controllers/api/v1/lesson_parts_controller.rb
+++ b/app/controllers/api/v1/lesson_parts_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::LessonPartsController < Api::BaseController
+  def index
+    lessons_parts = LessonPart
+      .where(lesson_id: params[:lesson_id])
+      .all
+
+    render(
+      json: SimpleAMS::Renderer::Collection.new(
+        lessons_parts,
+        serializer: LessonPartSerializer,
+        includes: []
+      ).to_json
+    )
+  end
+end

--- a/app/controllers/api/v1/lessons_controller.rb
+++ b/app/controllers/api/v1/lessons_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::LessonsController < Api::BaseController
       json: SimpleAMS::Renderer::Collection.new(
         lessons,
         serializer: LessonSerializer,
-        included: []
+        includes: []
       ).to_json
     )
   end

--- a/app/serializers/lesson_part_serializer.rb
+++ b/app/serializers/lesson_part_serializer.rb
@@ -1,0 +1,9 @@
+class LessonPartSerializer
+  include SimpleAMS::DSL
+
+  adapter SimpleAMS::Adapters::AMS, root: false
+
+  fields :id, :position
+
+  belongs_to :lesson, serializer: LessonSerializer
+end

--- a/app/serializers/lesson_serializer.rb
+++ b/app/serializers/lesson_serializer.rb
@@ -7,4 +7,5 @@ class LessonSerializer
          :previous_knowledge, :vocabulary, :misconceptions
 
   belongs_to :unit, serializer: UnitSerializer
+  has_many :lesson_parts, serializer: LessonPartSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
       resources :ccps, controller: 'complete_curriculum_programmes', only: %i(index show create update) do
         resources :units, only: %i(index show create update) do
           resources :lessons, only: %i(index show create update) do
-            resources :lesson_parts, only: %i(index show)
+            resources :lesson_parts, only: %i(index show create update)
           end
         end
       end

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -357,6 +357,70 @@
             }
           }
         }
+      },
+      "post": {
+        "summary": "creates a lesson part belonging to the specified lesson",
+        "tags": [
+          "LessonPart"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "lesson_part": {
+                    "$ref": "#/components/schemas/lesson_part",
+                    "required": [
+                      "lesson_part"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "lesson created",
+            "examples": {
+              "application/json": {
+                "lesson_part": {
+                  "position": 1
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid lesson part"
+          }
+        }
       }
     },
     "/ccps/{ccp_id}/units/{unit_id}/lessons": {

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -310,37 +310,11 @@
             "examples": {
               "application/json": [
                 {
-                  "name": "Lesson 1",
-                  "summary": "Lesson 1",
-                  "core_knowledge": "Core knowledge",
-                  "previous_knowledge": {
-                    "Previous knowledge": "Yes"
-                  },
-                  "vocabulary": [
-                    "Subtraction",
-                    "Division",
-                    "Multiplication"
-                  ],
-                  "misconceptions": [
-                    "Fractions are not natural numbers"
-                  ],
+                  "position": 1,
                   "id": 1
                 },
                 {
-                  "name": "Lesson 2",
-                  "summary": "Lesson 2",
-                  "core_knowledge": "Core knowledge",
-                  "previous_knowledge": {
-                    "Previous knowledge": "Yes"
-                  },
-                  "vocabulary": [
-                    "Subtraction",
-                    "Division",
-                    "Multiplication"
-                  ],
-                  "misconceptions": [
-                    "Fractions are not natural numbers"
-                  ],
+                  "position": 2,
                   "id": 2
                 }
               ]
@@ -412,7 +386,7 @@
             "examples": {
               "application/json": {
                 "lesson_part": {
-                  "position": 1
+                  "position": 3
                 }
               }
             }
@@ -483,20 +457,7 @@
             "description": "lesson part found",
             "examples": {
               "application/json": {
-                "name": "Lesson 3",
-                "summary": "Lesson 3",
-                "core_knowledge": "Core knowledge",
-                "previous_knowledge": {
-                  "Previous knowledge": "Yes"
-                },
-                "vocabulary": [
-                  "Subtraction",
-                  "Division",
-                  "Multiplication"
-                ],
-                "misconceptions": [
-                  "Fractions are not natural numbers"
-                ],
+                "position": 4,
                 "id": 1
               }
             },
@@ -572,7 +533,7 @@
             "examples": {
               "application/json": {
                 "lesson_part": {
-                  "position": 2
+                  "position": 5
                 }
               }
             }
@@ -613,8 +574,8 @@
             "examples": {
               "application/json": [
                 {
-                  "name": "Lesson 4",
-                  "summary": "Lesson 4",
+                  "name": "Lesson 1",
+                  "summary": "Lesson 1",
                   "core_knowledge": "Core knowledge",
                   "previous_knowledge": {
                     "Previous knowledge": "Yes"
@@ -630,8 +591,8 @@
                   "id": 1
                 },
                 {
-                  "name": "Lesson 5",
-                  "summary": "Lesson 5",
+                  "name": "Lesson 2",
+                  "summary": "Lesson 2",
                   "core_knowledge": "Core knowledge",
                   "previous_knowledge": {
                     "Previous knowledge": "Yes"
@@ -707,8 +668,8 @@
             "examples": {
               "application/json": {
                 "lesson": {
-                  "name": "Lesson 6",
-                  "summary": "Lesson 6",
+                  "name": "Lesson 3",
+                  "summary": "Lesson 3",
                   "core_knowledge": "Core knowledge",
                   "previous_knowledge": {
                     "Previous knowledge": "Yes"
@@ -783,8 +744,8 @@
             "description": "lesson found",
             "examples": {
               "application/json": {
-                "name": "Lesson 7",
-                "summary": "Lesson 7",
+                "name": "Lesson 4",
+                "summary": "Lesson 4",
                 "core_knowledge": "Core knowledge",
                 "previous_knowledge": {
                   "Previous knowledge": "Yes"
@@ -864,8 +825,8 @@
             "examples": {
               "application/json": {
                 "lesson": {
-                  "name": "Lesson 8",
-                  "summary": "Lesson 8",
+                  "name": "Lesson 5",
+                  "summary": "Lesson 5",
                   "core_knowledge": "Core knowledge",
                   "previous_knowledge": {
                     "Previous knowledge": "Yes"
@@ -1029,8 +990,8 @@
                 },
                 "lessons": [
                   {
-                    "name": "Lesson 9",
-                    "summary": "Lesson 9",
+                    "name": "Lesson 6",
+                    "summary": "Lesson 6",
                     "core_knowledge": "Core knowledge",
                     "previous_knowledge": {
                       "Previous knowledge": "Yes"
@@ -1046,8 +1007,8 @@
                     "id": 1
                   },
                   {
-                    "name": "Lesson 10",
-                    "summary": "Lesson 10",
+                    "name": "Lesson 7",
+                    "summary": "Lesson 7",
                     "core_knowledge": "Core knowledge",
                     "previous_knowledge": {
                       "Previous knowledge": "Yes"
@@ -1063,8 +1024,8 @@
                     "id": 2
                   },
                   {
-                    "name": "Lesson 11",
-                    "summary": "Lesson 11",
+                    "name": "Lesson 8",
+                    "summary": "Lesson 8",
                     "core_knowledge": "Core knowledge",
                     "previous_knowledge": {
                       "Previous knowledge": "Yes"

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -423,6 +423,166 @@
         }
       }
     },
+    "/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{id}": {
+      "get": {
+        "summary": "retrieves a single lesson part belonging to the specified CCP, unit and lesson",
+        "tags": [
+          "LessonPart"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "$ref": "#/components/schemas/lesson_part",
+                  "required": [
+                    "lesson_part"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "lesson part found",
+            "examples": {
+              "application/json": {
+                "name": "Lesson 3",
+                "summary": "Lesson 3",
+                "core_knowledge": "Core knowledge",
+                "previous_knowledge": {
+                  "Previous knowledge": "Yes"
+                },
+                "vocabulary": [
+                  "Subtraction",
+                  "Division",
+                  "Multiplication"
+                ],
+                "misconceptions": [
+                  "Fractions are not natural numbers"
+                ],
+                "id": 1
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/lesson_part"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "update the referenced lesson part",
+        "tags": [
+          "LessonPart"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "lesson_part": {
+                    "$ref": "#/components/schemas/lesson_part",
+                    "required": [
+                      "lesson_part"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "lesson part updated",
+            "examples": {
+              "application/json": {
+                "lesson_part": {
+                  "position": 2
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid lesson part"
+          }
+        }
+      }
+    },
     "/ccps/{ccp_id}/units/{unit_id}/lessons": {
       "get": {
         "summary": "retrieves all lessons belonging to the specified CCP and unit",
@@ -453,8 +613,8 @@
             "examples": {
               "application/json": [
                 {
-                  "name": "Lesson 3",
-                  "summary": "Lesson 3",
+                  "name": "Lesson 4",
+                  "summary": "Lesson 4",
                   "core_knowledge": "Core knowledge",
                   "previous_knowledge": {
                     "Previous knowledge": "Yes"
@@ -470,8 +630,8 @@
                   "id": 1
                 },
                 {
-                  "name": "Lesson 4",
-                  "summary": "Lesson 4",
+                  "name": "Lesson 5",
+                  "summary": "Lesson 5",
                   "core_knowledge": "Core knowledge",
                   "previous_knowledge": {
                     "Previous knowledge": "Yes"
@@ -547,8 +707,8 @@
             "examples": {
               "application/json": {
                 "lesson": {
-                  "name": "Lesson 5",
-                  "summary": "Lesson 5",
+                  "name": "Lesson 6",
+                  "summary": "Lesson 6",
                   "core_knowledge": "Core knowledge",
                   "previous_knowledge": {
                     "Previous knowledge": "Yes"
@@ -623,8 +783,8 @@
             "description": "lesson found",
             "examples": {
               "application/json": {
-                "name": "Lesson 6",
-                "summary": "Lesson 6",
+                "name": "Lesson 7",
+                "summary": "Lesson 7",
                 "core_knowledge": "Core knowledge",
                 "previous_knowledge": {
                   "Previous knowledge": "Yes"
@@ -704,8 +864,8 @@
             "examples": {
               "application/json": {
                 "lesson": {
-                  "name": "Lesson 7",
-                  "summary": "Lesson 7",
+                  "name": "Lesson 8",
+                  "summary": "Lesson 8",
                   "core_knowledge": "Core knowledge",
                   "previous_knowledge": {
                     "Previous knowledge": "Yes"
@@ -869,8 +1029,8 @@
                 },
                 "lessons": [
                   {
-                    "name": "Lesson 8",
-                    "summary": "Lesson 8",
+                    "name": "Lesson 9",
+                    "summary": "Lesson 9",
                     "core_knowledge": "Core knowledge",
                     "previous_knowledge": {
                       "Previous knowledge": "Yes"
@@ -886,8 +1046,8 @@
                     "id": 1
                   },
                   {
-                    "name": "Lesson 9",
-                    "summary": "Lesson 9",
+                    "name": "Lesson 10",
+                    "summary": "Lesson 10",
                     "core_knowledge": "Core knowledge",
                     "previous_knowledge": {
                       "Previous knowledge": "Yes"
@@ -903,8 +1063,8 @@
                     "id": 2
                   },
                   {
-                    "name": "Lesson 10",
-                    "summary": "Lesson 10",
+                    "name": "Lesson 11",
+                    "summary": "Lesson 11",
                     "core_knowledge": "Core knowledge",
                     "previous_knowledge": {
                       "Previous knowledge": "Yes"

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -63,7 +63,7 @@
             "type": "string"
           },
           "previous_knowledge": {
-            "type": "string"
+            "type": "object"
           },
           "vocabulary": {
             "type": "array",
@@ -86,6 +86,17 @@
           "vocabulary",
           "misconceptions"
         ]
+      },
+      "lesson_part": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "position": {
+            "type": "integer"
+          }
+        }
       }
     }
   },
@@ -261,6 +272,93 @@
         }
       }
     },
+    "/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts": {
+      "get": {
+        "summary": "retrieves all lessons parts belonging to the specified lesson",
+        "tags": [
+          "LessonPart"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "lesson parts found",
+            "examples": {
+              "application/json": [
+                {
+                  "name": "Lesson 1",
+                  "summary": "Lesson 1",
+                  "core_knowledge": "Core knowledge",
+                  "previous_knowledge": {
+                    "Previous knowledge": "Yes"
+                  },
+                  "vocabulary": [
+                    "Subtraction",
+                    "Division",
+                    "Multiplication"
+                  ],
+                  "misconceptions": [
+                    "Fractions are not natural numbers"
+                  ],
+                  "id": 1
+                },
+                {
+                  "name": "Lesson 2",
+                  "summary": "Lesson 2",
+                  "core_knowledge": "Core knowledge",
+                  "previous_knowledge": {
+                    "Previous knowledge": "Yes"
+                  },
+                  "vocabulary": [
+                    "Subtraction",
+                    "Division",
+                    "Multiplication"
+                  ],
+                  "misconceptions": [
+                    "Fractions are not natural numbers"
+                  ],
+                  "id": 2
+                }
+              ]
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/lesson_part"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ccps/{ccp_id}/units/{unit_id}/lessons": {
       "get": {
         "summary": "retrieves all lessons belonging to the specified CCP and unit",
@@ -291,10 +389,12 @@
             "examples": {
               "application/json": [
                 {
-                  "name": "Lesson 1",
-                  "summary": "Lesson 1",
+                  "name": "Lesson 3",
+                  "summary": "Lesson 3",
                   "core_knowledge": "Core knowledge",
-                  "previous_knowledge": "Previous knowledge",
+                  "previous_knowledge": {
+                    "Previous knowledge": "Yes"
+                  },
                   "vocabulary": [
                     "Subtraction",
                     "Division",
@@ -306,10 +406,12 @@
                   "id": 1
                 },
                 {
-                  "name": "Lesson 2",
-                  "summary": "Lesson 2",
+                  "name": "Lesson 4",
+                  "summary": "Lesson 4",
                   "core_knowledge": "Core knowledge",
-                  "previous_knowledge": "Previous knowledge",
+                  "previous_knowledge": {
+                    "Previous knowledge": "Yes"
+                  },
                   "vocabulary": [
                     "Subtraction",
                     "Division",
@@ -381,10 +483,12 @@
             "examples": {
               "application/json": {
                 "lesson": {
-                  "name": "Lesson 3",
-                  "summary": "Lesson 3",
+                  "name": "Lesson 5",
+                  "summary": "Lesson 5",
                   "core_knowledge": "Core knowledge",
-                  "previous_knowledge": "Previous knowledge",
+                  "previous_knowledge": {
+                    "Previous knowledge": "Yes"
+                  },
                   "vocabulary": [
                     "Subtraction",
                     "Division",
@@ -455,10 +559,12 @@
             "description": "lesson found",
             "examples": {
               "application/json": {
-                "name": "Lesson 4",
-                "summary": "Lesson 4",
+                "name": "Lesson 6",
+                "summary": "Lesson 6",
                 "core_knowledge": "Core knowledge",
-                "previous_knowledge": "Previous knowledge",
+                "previous_knowledge": {
+                  "Previous knowledge": "Yes"
+                },
                 "vocabulary": [
                   "Subtraction",
                   "Division",
@@ -534,10 +640,12 @@
             "examples": {
               "application/json": {
                 "lesson": {
-                  "name": "Lesson 5",
-                  "summary": "Lesson 5",
+                  "name": "Lesson 7",
+                  "summary": "Lesson 7",
                   "core_knowledge": "Core knowledge",
-                  "previous_knowledge": "Previous knowledge",
+                  "previous_knowledge": {
+                    "Previous knowledge": "Yes"
+                  },
                   "vocabulary": [
                     "Subtraction",
                     "Division",
@@ -697,10 +805,12 @@
                 },
                 "lessons": [
                   {
-                    "name": "Lesson 6",
-                    "summary": "Lesson 6",
+                    "name": "Lesson 8",
+                    "summary": "Lesson 8",
                     "core_knowledge": "Core knowledge",
-                    "previous_knowledge": "Previous knowledge",
+                    "previous_knowledge": {
+                      "Previous knowledge": "Yes"
+                    },
                     "vocabulary": [
                       "Subtraction",
                       "Division",
@@ -712,10 +822,12 @@
                     "id": 1
                   },
                   {
-                    "name": "Lesson 7",
-                    "summary": "Lesson 7",
+                    "name": "Lesson 9",
+                    "summary": "Lesson 9",
                     "core_knowledge": "Core knowledge",
-                    "previous_knowledge": "Previous knowledge",
+                    "previous_knowledge": {
+                      "Previous knowledge": "Yes"
+                    },
                     "vocabulary": [
                       "Subtraction",
                       "Division",
@@ -727,10 +839,12 @@
                     "id": 2
                   },
                   {
-                    "name": "Lesson 8",
-                    "summary": "Lesson 8",
+                    "name": "Lesson 10",
+                    "summary": "Lesson 10",
                     "core_knowledge": "Core knowledge",
-                    "previous_knowledge": "Previous knowledge",
+                    "previous_knowledge": {
+                      "Previous knowledge": "Yes"
+                    },
                     "vocabulary": [
                       "Subtraction",
                       "Division",

--- a/spec/integration/api/v1/lesson_parts_spec.rb
+++ b/spec/integration/api/v1/lesson_parts_spec.rb
@@ -80,4 +80,37 @@ describe 'Lessons' do
       end
     end
   end
+
+  path('/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{id}') do
+
+    get('retrieves a single lesson part belonging to the specified CCP, unit and lesson') do
+      tags('LessonPart')
+      produces('application/json')
+
+      let(:lesson_part) { FactoryBot.create(:lesson_part) }
+
+      let(:ccp_id) { lesson_part.lesson.unit.complete_curriculum_programme.id }
+      let(:unit_id) { lesson_part.lesson.unit.id }
+      let(:lesson_id) { lesson_part.lesson.id }
+      let(:id) { lesson_part.id }
+
+      parameter(name: :ccp_id, in: :path, type: :string, required: true)
+      parameter(name: :unit_id, in: :path, type: :string, required: true)
+      parameter(name: :lesson_id, in: :path, type: :string, required: true)
+      parameter(name: :id, in: :path, type: :string, required: true)
+
+      request_body_json(
+        schema: {
+          properties: { '$ref' => '#/components/schemas/lesson_part', required: %i(lesson_part) }
+        }
+      )
+
+      response('200', 'lesson part found') do
+        examples('application/json': example_lesson)
+
+        schema('$ref' => '#/components/schemas/lesson_part')
+
+        run_test!
+      end
+    end
 end

--- a/spec/integration/api/v1/lesson_parts_spec.rb
+++ b/spec/integration/api/v1/lesson_parts_spec.rb
@@ -1,0 +1,28 @@
+require 'swagger_helper'
+
+describe 'Lessons' do
+  path('/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts') do
+    get('retrieves all lessons parts belonging to the specified lesson') do
+      tags('LessonPart')
+      produces('application/json')
+
+      let(:lesson_part) { FactoryBot.create(:lesson_part) }
+
+      let(:ccp_id) { lesson_part.lesson.unit.complete_curriculum_programme.id }
+      let(:unit_id) { lesson_part.lesson.unit.id }
+      let(:lesson_id) { lesson_part.lesson.id }
+
+      parameter(name: :ccp_id, in: :path, type: :string, required: true)
+      parameter(name: :unit_id, in: :path, type: :string, required: true)
+      parameter(name: :lesson_id, in: :path, type: :string, required: true)
+
+      response '200', 'lesson parts found' do
+        examples('application/json': example_lessons(2))
+
+        schema(type: :array, items: { '$ref' => '#/components/schemas/lesson_part' })
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/api/v1/lesson_parts_spec.rb
+++ b/spec/integration/api/v1/lesson_parts_spec.rb
@@ -17,7 +17,7 @@ describe 'Lessons' do
       parameter(name: :lesson_id, in: :path, type: :string, required: true)
 
       response '200', 'lesson parts found' do
-        examples('application/json': example_lessons(2))
+        examples('application/json': example_lesson_parts(2))
 
         schema(type: :array, items: { '$ref' => '#/components/schemas/lesson_part' })
 
@@ -105,7 +105,7 @@ describe 'Lessons' do
       )
 
       response('200', 'lesson part found') do
-        examples('application/json': example_lesson)
+        examples('application/json': example_lesson_part)
 
         schema('$ref' => '#/components/schemas/lesson_part')
 

--- a/spec/integration/api/v1/lesson_parts_spec.rb
+++ b/spec/integration/api/v1/lesson_parts_spec.rb
@@ -82,7 +82,6 @@ describe 'Lessons' do
   end
 
   path('/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{id}') do
-
     get('retrieves a single lesson part belonging to the specified CCP, unit and lesson') do
       tags('LessonPart')
       produces('application/json')
@@ -113,4 +112,62 @@ describe 'Lessons' do
         run_test!
       end
     end
+
+    patch('update the referenced lesson part') do
+      tags('LessonPart')
+
+      consumes 'application/json'
+
+      let(:lesson_part) { FactoryBot.create(:lesson_part) }
+      let(:lesson) { lesson_part.lesson }
+      let(:unit) { lesson.unit }
+      let(:ccp) { unit.complete_curriculum_programme }
+
+      let(:id) { lesson_part.id }
+      let(:lesson_id) { lesson.id }
+      let(:unit_id) { unit.id }
+      let(:ccp_id) { ccp.id }
+
+      let(:lesson_part_params) { { lesson_part: FactoryBot.attributes_for(:lesson_part) } }
+
+      parameter(name: :ccp_id, in: :path, type: :string, required: true)
+      parameter(name: :unit_id, in: :path, type: :string, required: true)
+      parameter(name: :lesson_id, in: :path, type: :string, required: true)
+      parameter(name: :id, in: :path, type: :string, required: true)
+
+      parameter(
+        name: :lesson_part_params,
+        in: :body,
+        schema: {
+          properties: {
+            lesson_part: {
+              '$ref' => '#/components/schemas/lesson_part', required: %i(lesson_part)
+            }
+          }
+        }
+      )
+
+      request_body_json(schema: { '$ref' => '#/components/schemas/lesson_part' })
+
+      response(200, 'lesson part updated') do
+        examples('application/json': { lesson_part: FactoryBot.attributes_for(:lesson_part) })
+
+        run_test! do |response|
+          JSON.parse(response.body).with_indifferent_access.tap do |json|
+            lesson_part_params.dig(:lesson_part).each do |attribute, value|
+              expect(json[attribute]).to eql(value)
+            end
+          end
+        end
+      end
+
+      response(400, 'invalid lesson part') do
+        let(:lesson_part_params) { { lesson_part: FactoryBot.attributes_for(:lesson_part, position: nil) } }
+
+        run_test! do |response|
+          expect(JSON.parse(response.body).dig('errors')).to include(%(Position can't be blank))
+        end
+      end
+    end
+  end
 end

--- a/spec/integration/api/v1/lesson_parts_spec.rb
+++ b/spec/integration/api/v1/lesson_parts_spec.rb
@@ -24,5 +24,60 @@ describe 'Lessons' do
         run_test!
       end
     end
+
+    post('creates a lesson part belonging to the specified lesson') do
+      tags('LessonPart')
+      consumes 'application/json'
+
+      let(:lesson_part) { FactoryBot.create(:lesson_part) }
+
+      let(:ccp_id) { lesson_part.lesson.unit.complete_curriculum_programme.id }
+      let(:unit_id) { lesson_part.lesson.unit.id }
+      let(:lesson_id) { lesson_part.lesson.id }
+
+      parameter(name: :ccp_id, in: :path, type: :string, required: true)
+      parameter(name: :unit_id, in: :path, type: :string, required: true)
+      parameter(name: :lesson_id, in: :path, type: :string, required: true)
+
+      parameter(
+        name: :lesson_part_params,
+        in: :body,
+        schema: {
+          properties: {
+            lesson_part: {
+              '$ref' => '#/components/schemas/lesson_part', required: %i(lesson_part)
+            }
+          }
+        }
+      )
+
+      request_body_json(
+        schema: {
+          properties: { '$ref' => '#/components/schemas/lesson_part', required: %i(lesson_part) }
+        }
+      )
+
+      response(201, 'lesson created') do
+        let!(:lesson_part_params) { { lesson_part: FactoryBot.attributes_for(:lesson_part) } }
+
+        examples('application/json': { lesson_part: FactoryBot.attributes_for(:lesson_part) })
+
+        run_test! do |response|
+          JSON.parse(response.body).with_indifferent_access.tap do |json|
+            lesson_part_params.dig(:lesson_part).each do |attribute, value|
+              expect(json[attribute]).to eql(value)
+            end
+          end
+        end
+      end
+
+      response(400, 'invalid lesson part') do
+        let!(:lesson_part_params) { { lesson_part: FactoryBot.attributes_for(:lesson_part, position: nil) } }
+
+        run_test! do |response|
+          expect(JSON.parse(response.body).dig('errors')).to include(%(Position can't be blank))
+        end
+      end
+    end
   end
 end

--- a/spec/support/api_examples.rb
+++ b/spec/support/api_examples.rb
@@ -22,6 +22,14 @@ def example_lessons(quantity)
   1.upto(quantity).map { |i| example_lesson(i) }
 end
 
+def example_lesson_part(id = 1)
+  FactoryBot.attributes_for(:lesson_part).merge(id: id)
+end
+
+def example_lesson_parts(quantity)
+  1.upto(quantity).map { |i| example_lesson_part(i) }
+end
+
 def example_errors
   ["Name can't be blank"]
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -56,6 +56,13 @@ RSpec.configure do |config|
               },
             },
             required: %i(name summary core_knowledge previous_knowledge vocabulary misconceptions)
+          },
+          lesson_part: {
+            type: :object,
+            properties: {
+              id: { type: :integer },
+              position: { type: :integer }
+            }
           }
         }
       },


### PR DESCRIPTION
Extend the API down the hierarchy, now lesson parts are covered too.

Note that this is skeletal at the moment, there are no role/permissions or ownership checks and the attributes are likely to change.

![Screenshot from 2020-02-12 11-37-51](https://user-images.githubusercontent.com/128088/74331784-4fee5100-4d8c-11ea-9a4c-ba3503360a19.png)
