### PR TITLE
Adds default activity choice

### DIFF
--- a/app/controllers/api/v1/lesson_parts_controller.rb
+++ b/app/controllers/api/v1/lesson_parts_controller.rb
@@ -29,6 +29,7 @@ class Api::V1::LessonPartsController < Api::BaseController
     if lesson_part.save
       render(json: serialize(lesson_part).to_json, status: :created)
     else
+      byebug
       render(json: { errors: lesson_part.errors.full_messages }, status: :bad_request)
     end
   end
@@ -46,7 +47,7 @@ class Api::V1::LessonPartsController < Api::BaseController
 private
 
   def lesson_part_params
-    params.require(:lesson_part).permit(:position)
+    params.require(:lesson_part).permit(:position, :default_activity_choice_id)
   end
 
   def serialize(lesson_part)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,6 +3,6 @@ class Activity < ApplicationRecord
   has_many :activity_teaching_methods, dependent: :destroy
   has_many :teaching_methods, through: :activity_teaching_methods
 
-  validates :lesson_part_id, presence: true
+  validates :lesson_part, presence: true
   validates :duration, presence: true, numericality: { less_than_or_equal_to: 60 }
 end

--- a/app/models/lesson_part.rb
+++ b/app/models/lesson_part.rb
@@ -2,9 +2,23 @@ class LessonPart < ApplicationRecord
   belongs_to :lesson
   has_many :activities, dependent: :destroy
 
+  belongs_to :default_activity_choice, class_name: 'Activity'
+
+  before_validation :assign_default_activity_choice, only: :create
+
+  validates :default_activity_choice, presence: true
+
   validates :position,
             presence: true,
             numericality: { only_integer: true, greater_than: 0 }
 
   validates :position, uniqueness: { scope: :lesson_id }
+
+  private
+
+  def assign_default_activity_choice
+    unless self.default_activity_choice
+      self.default_activity_choice = activities.first
+    end
+  end
 end

--- a/db/migrate/20200207140945_create_lesson_parts.rb
+++ b/db/migrate/20200207140945_create_lesson_parts.rb
@@ -3,6 +3,7 @@ class CreateLessonParts < ActiveRecord::Migration[6.0]
     create_table :lesson_parts do |t|
       t.belongs_to :lesson, null: false
       t.integer :position, null: false
+      t.integer :default_activity_choice_id
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,6 +59,9 @@ ActiveRecord::Schema.define(version: 2020_02_12_080617) do
   create_table "lesson_parts", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.integer "position", null: false
+    t.integer "default_activity_choice_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["lesson_id"], name: "index_lesson_parts_on_lesson_id"
     t.index ["position", "lesson_id"], name: "index_lesson_parts_on_position_and_lesson_id", unique: true
   end

--- a/spec/factories/lesson_part.rb
+++ b/spec/factories/lesson_part.rb
@@ -2,5 +2,13 @@ FactoryBot.define do
   factory :lesson_part do
     sequence :position
     association :lesson, factory: :lesson
+
+    after :build do |lesson_part|
+      # We need atleast one activity to assign the default_activity_choice in
+      # the before_validation callback
+      if lesson_part.activities.empty?
+        lesson_part.activities = FactoryBot.build_list :activity, 5, lesson_part: lesson_part
+      end
+    end
   end
 end

--- a/spec/integration/api/v1/lesson_parts_spec.rb
+++ b/spec/integration/api/v1/lesson_parts_spec.rb
@@ -58,9 +58,9 @@ describe 'Lessons' do
       )
 
       response(201, 'lesson created') do
-        let!(:lesson_part_params) { { lesson_part: FactoryBot.attributes_for(:lesson_part) } }
+        let!(:lesson_part_params) { { lesson_part: FactoryBot.create(:lesson_part).attributes } }
 
-        examples('application/json': { lesson_part: FactoryBot.attributes_for(:lesson_part) })
+        examples('application/json': { lesson_part: FactoryBot.create(:lesson_part).attributes })
 
         run_test! do |response|
           JSON.parse(response.body).with_indifferent_access.tap do |json|

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Activity, type: :model do
   end
 
   describe 'validation' do
-    it { is_expected.to validate_presence_of(:lesson_part_id) }
+    it { is_expected.to validate_presence_of(:lesson_part) }
 
     describe '#duration' do
       it { is_expected.to validate_presence_of(:duration) }

--- a/spec/models/lesson_part_spec.rb
+++ b/spec/models/lesson_part_spec.rb
@@ -6,23 +6,28 @@ describe LessonPart, type: :model do
       is_expected.to have_db_column(:lesson_id).of_type(:integer).with_options \
         null: false
     end
+
     it do
       is_expected.to have_db_column(:position).of_type(:integer).with_options \
         null: false
+    end
+
+    it do
+      is_expected.to \
+        have_db_column(:default_activity_choice_id).of_type(:integer)
     end
   end
 
   describe 'relationships' do
     it { is_expected.to belong_to :lesson }
     it { is_expected.to have_many(:activities).dependent(:destroy) }
+    it { is_expected.to belong_to :default_activity_choice }
   end
 
   describe 'validations' do
     it { is_expected.to validate_presence_of :position }
 
     it do
-      # explicit create to work around bug in shoulda when null constraint on
-      # column see https://github.com/thoughtbot/shoulda-matchers/issues/535
       expect(create(:lesson_part)).to \
         validate_uniqueness_of(:position).scoped_to :lesson_id
     end


### PR DESCRIPTION
### Context
We want to provide teachers with a default activity for a lesson part,
such that they can download a lesson plan without having to make
changes to the suggested activity.
A lesson part should only have one default activity.

### Changes proposed in this pull request
Adds a default_activity_choice_id to the LessonPart model.

### Guidance to review
Compare this pull request with [this one](https://github.com/DFE-Digital/curriculum-materials/pull/57) I'm leaning towards #57 as it "feels" better and we avoid the need for a callback. There's probably a nicer way to do this and keep the default_activity_choice_id on the lesson part and I'm not 100% either way, just I had to change fewer files with the boolean flag on activity approach!

Note this pr updates the original create lesson_part migration to add the new column as
at this point in development we're happy to drop the database.