### PR TITLE
Adds default activity choice

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -5,4 +5,7 @@ class Activity < ApplicationRecord
 
   validates :lesson_part_id, presence: true
   validates :duration, presence: true, numericality: { less_than_or_equal_to: 60 }
+
+  validates :default, inclusion: [true, false]
+  validates :default, uniqueness: { scope: :lesson_part_id }, if: :default?
 end

--- a/db/migrate/20200211134442_create_activities.rb
+++ b/db/migrate/20200211134442_create_activities.rb
@@ -5,6 +5,7 @@ class CreateActivities < ActiveRecord::Migration[6.0]
       t.text :overview
       t.integer :duration, null: false
       t.string :extra_requirements, limit: 32, array: true
+      t.boolean :default, null: false
       t.timestamps
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_02_12_080617) do
     t.text "overview"
     t.integer "duration", null: false
     t.string "extra_requirements", limit: 32, array: true
+    t.boolean "default", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["lesson_part_id"], name: "index_activities_on_lesson_part_id"
@@ -59,6 +60,8 @@ ActiveRecord::Schema.define(version: 2020_02_12_080617) do
   create_table "lesson_parts", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.integer "position", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["lesson_id"], name: "index_lesson_parts_on_lesson_id"
     t.index ["position", "lesson_id"], name: "index_lesson_parts_on_position_and_lesson_id", unique: true
   end

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -4,6 +4,12 @@ FactoryBot.define do
     sequence(:overview) { |n| "Overview #{n}" }
     duration { 20 }
 
+    after :build do |activity|
+      if activity.default == nil && activity.lesson_part.activities.none?(&:default?)
+        activity.default = true
+      end
+    end
+
     trait(:randomised) do
       overview { Faker::Lorem.paragraph }
       duration { 20.step(to: 60, by: 5).to_a.sample }

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Activity, type: :model do
     it { is_expected.to have_db_column(:overview).of_type(:text) }
     it { is_expected.to have_db_column(:duration).of_type(:integer) }
     it { is_expected.to have_db_column(:extra_requirements).of_type(:string).with_options(array: true) }
+    it { is_expected.to have_db_column(:default).of_type(:boolean).with_options(null: false) }
   end
 
   describe 'relationships' do
@@ -20,6 +21,26 @@ RSpec.describe Activity, type: :model do
     describe '#duration' do
       it { is_expected.to validate_presence_of(:duration) }
       it { is_expected.to validate_numericality_of(:duration).is_less_than_or_equal_to(60) }
+    end
+
+    describe '#default' do
+      context 'when default' do
+        subject { create :activity, default: true }
+
+        it do
+          is_expected.to \
+            validate_uniqueness_of(:default).scoped_to(:lesson_part_id)
+        end
+      end
+
+      context 'when not default' do
+        subject { create :activity, default: false }
+
+        it do
+          is_expected.not_to \
+            validate_uniqueness_of(:default).scoped_to(:lesson_part_id)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
We want to provide teachers with a default activity for a lesson part,
such that they can download a lesson plan without having to make
changes to the suggested activity.
A lesson part should only have one default activity.

### Changes proposed in this pull request
Adds a default boolean flag to the activity

### Guidance to review
Compare this pr with [this one](https://github.com/DFE-Digital/curriculum-materials/pull/56) where the default activity is indicated by `LessonPart#default_activity_choice_id`. Using a boolean flag on activity "feels" nice in ruby code as we have to do less stuff and there's no callback surprises. However I'm not sold either way.

Note this pr updates the original create activity migration to add the new column as
at this point in development we're happy to drop the database.

