### PR TITLE
✨ Support print of lesson plan page

### DIFF
--- a/app/controllers/teachers/lessons_controller.rb
+++ b/app/controllers/teachers/lessons_controller.rb
@@ -1,6 +1,16 @@
 module Teachers
   class LessonsController < BaseController
-    def show
+    before_action :load_resources, only: %i[show print]
+
+    def show; end
+
+    def print
+      render layout: 'print'
+    end
+
+    private
+
+    def load_resources
       @lesson = Lesson.find(params[:id])
 
       # lifted from prototype, these fields should guide

--- a/app/views/layouts/print.slim
+++ b/app/views/layouts/print.slim
@@ -1,0 +1,15 @@
+doctype html
+
+html lang="en" class="govuk-template "
+  head
+    title
+      | Curriculum Materials
+    = tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' 
+    = stylesheet_pack_tag 'application'
+    = javascript_pack_tag "print", defer: true, async: true
+
+  body.govuk-template__body
+    .govuk-width-container
+      main#main-content.govuk-main-wrapper[role="main"]
+        = yield
+    = render 'layouts/shared/footer'

--- a/app/views/teachers/lessons/_core_knowledge.slim
+++ b/app/views/teachers/lessons/_core_knowledge.slim
@@ -1,5 +1,6 @@
 section.core-knowledge-for-teachers
-  h2.govuk-heading-m Core knowledge for teachers
+  h2.govuk-heading-m
+    =t(:heading, scope: :core_knowledge)
 
   p
     = lesson.core_knowledge

--- a/app/views/teachers/lessons/_downloads.slim
+++ b/app/views/teachers/lessons/_downloads.slim
@@ -2,7 +2,6 @@ section.downloads
   h3.govuk-heading-m Download this lesson plan and its resources
 
   ul.govuk-list
-    li
-      a href="javascript:window.print()" Print lesson plan
+    li = link_to("Print lesson plan", print_teachers_lesson_path(auto_print: true), target: "_blank")
     li = link_to("Download teacher resources", "#")
     li = link_to("Download pupil resources", "#")

--- a/app/views/teachers/lessons/_downloads.slim
+++ b/app/views/teachers/lessons/_downloads.slim
@@ -2,6 +2,7 @@ section.downloads
   h3.govuk-heading-m Download this lesson plan and its resources
 
   ul.govuk-list
-    li = link_to("Download lesson plan", "#")
+    li
+      a href="javascript:window.print()" Print lesson plan
     li = link_to("Download teacher resources", "#")
     li = link_to("Download pupil resources", "#")

--- a/app/views/teachers/lessons/_lesson_contents.slim
+++ b/app/views/teachers/lessons/_lesson_contents.slim
@@ -13,8 +13,9 @@ section.lesson-plan
           | Learning method
         th.govuk-table__header scope='col'
           | Teaching this activity
-        th.alternative-content.govuk-table__header scope='col'
-          | Change activity
+        - unless local_assigns[:mode] && mode == :print
+          th.alternative-content.govuk-table__header scope='col'
+            | Change activity
 
     tbody.govuk-table__body
       - @lesson_parts.each do |lp|
@@ -46,11 +47,12 @@ section.lesson-plan
               - lp.extra_requirements.each do |er|
                 .govuk-tag = er
 
-          td.alternative-content.govuk-table__cell
-            - if lp.alternatives.any?
-              ul.govuk-list
-                - lp.alternatives.each do |alternative|
-                  li
-                    strong = alternative
+          - unless local_assigns[:mode] && mode == :print
+            td.alternative-content.govuk-table__cell
+              - if lp.alternatives.any?
+                ul.govuk-list
+                  - lp.alternatives.each do |alternative|
+                    li
+                      strong = alternative
 
-              = link_to 'Change activity', '#'
+                = link_to 'Change activity', '#'

--- a/app/views/teachers/lessons/_lesson_contents.slim
+++ b/app/views/teachers/lessons/_lesson_contents.slim
@@ -13,7 +13,7 @@ section.lesson-plan
           | Learning method
         th.govuk-table__header scope='col'
           | Teaching this activity
-        th.govuk-table__header scope='col'
+        th.alternative-content.govuk-table__header scope='col'
           | Change activity
 
     tbody.govuk-table__body
@@ -46,7 +46,7 @@ section.lesson-plan
               - lp.extra_requirements.each do |er|
                 .govuk-tag = er
 
-          td.govuk-table__cell
+          td.alternative-content.govuk-table__cell
             - if lp.alternatives.any?
               ul.govuk-list
                 - lp.alternatives.each do |alternative|

--- a/app/views/teachers/lessons/print.slim
+++ b/app/views/teachers/lessons/print.slim
@@ -1,0 +1,19 @@
+.govuk-grid-row
+  .govuk-grid-column-full
+    h1.govuk-heading-l
+      = @lesson.name
+    
+    h2
+      =t(:heading, scope: :knowledge_overview)
+
+    = markdown(@lesson.summary)
+    = render 'core_knowledge', lesson: @lesson
+    = render 'vocabulary', lesson: @lesson
+    = render 'misconceptions', lesson: @lesson
+    = render 'previous_knowledge', lesson: @lesson
+    
+    h2
+      =t(:heading, scope: :lesson_contents)
+
+    = render 'lesson_contents', lesson: @lesson, mode: :print
+

--- a/app/views/teachers/lessons/show.slim
+++ b/app/views/teachers/lessons/show.slim
@@ -18,7 +18,8 @@
           = link_to 'Downloads', '#downloads', class: 'govuk-tabs__tab'
 
       section#knowledge-overview.govuk-tabs__panel
-        h2 Understand the aims of the lesson
+        h2
+          =t(:heading, scope: :knowledge_overview)
 
         = markdown(@lesson.summary)
         = render 'core_knowledge', lesson: @lesson
@@ -27,7 +28,8 @@
         = render 'previous_knowledge', lesson: @lesson
 
       section#lesson-contents.govuk-tabs__panel
-        h2 Lesson contents
+        h2
+          =t(:heading, scope: :lesson_contents)
 
         = render 'lesson_contents', lesson: @lesson
 

--- a/app/webpacker/packs/print.js
+++ b/app/webpacker/packs/print.js
@@ -1,0 +1,10 @@
+function initAutoPrint() {
+  let autoPrint = window.location.href.search('[?&]auto_print') != -1
+  if (autoPrint) {
+    window.print();
+  }
+}
+
+window.addEventListener('load', () => {
+  initAutoPrint()
+})

--- a/app/webpacker/styles/_print.scss
+++ b/app/webpacker/styles/_print.scss
@@ -1,0 +1,25 @@
+@media print {
+  @page {
+    margin: 2rem;
+  }
+
+  a.govuk-footer__copyright-logo::after {
+    display: none;
+  }
+
+  .govuk-header,
+  .govuk-phase-banner,
+  .govuk-breadcrumbs,
+  .govuk-tabs .govuk-tabs__list,
+  .govuk-tabs .govuk-tabs__title,
+  .govuk-table__header.alternative-content,
+  .govuk-table__cell.alternative-content,
+  #downloads.govuk-tabs__panel
+  {
+    display: none;
+  }
+
+  #lesson-contents.govuk-tabs__panel {
+    page-break-before: always;
+  }
+}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -19,3 +19,4 @@ $govuk-image-url-function: frontend-image-url;
 @import "lessons";
 @import "utility";
 @import "logout_button";
+@import "print";

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,5 @@ en:
     heading: Understand the aims of the lesson
   lesson_contents:
     heading: Lesson contents
+  core_knowledge:
+    heading: Core knowledge for teachers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,7 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  knowledge_overview:
+    heading: Understand the aims of the lesson
+  lesson_contents:
+    heading: Lesson contents

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,11 @@ Rails.application.routes.draw do
     resources :complete_curriculum_programmes, only: %i(index show)
 
     resources :units, only: %i(show)
-    resources :lessons, only: %i(show)
+    resources :lessons, only: %i(show) do
+      member do
+        get :print
+      end
+    end
 
     resource :logged_out, only: %i(show), controller: 'logged_out'
   end

--- a/spec/controllers/teachers/lessons_controller_spec.rb
+++ b/spec/controllers/teachers/lessons_controller_spec.rb
@@ -10,3 +10,21 @@ describe Teachers::LessonsController, type: :request do
     it { is_expected.to render_template('show') }
   end
 end
+
+
+describe Teachers::LessonsController, type: :controller do
+  let(:teacher) { FactoryBot.create(:teacher) }
+
+  context "GET #print" do
+    let(:lesson) { FactoryBot.create(:lesson) }
+    subject { get :print, params: { id: lesson.id } }
+
+    before :each do
+      controller.session[:token] = teacher.token
+    end
+
+    it "renders with 'print' layout" do
+      expect(subject).to render_template("layouts/print")
+    end
+  end
+end

--- a/spec/features/lessons/print_spec.rb
+++ b/spec/features/lessons/print_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature "Lesson print", type: :feature do
+  include_context 'logged in teacher'
+
+  describe '#show' do
+    let(:lesson) { FactoryBot.create(:lesson) }
+    let(:lesson_part_count) { 2 }
+    let!(:lesson_parts) { create_list(:lesson_part, lesson_part_count, :with_activities, lesson: lesson) }
+
+    before { visit print_teachers_lesson_path(lesson) }
+
+    specify "the page contains the lesson title" do
+      expect(page).to have_content(lesson.name)
+    end
+
+    specify "the page contains the lesson activities" do
+      expect(page).to have_css('table.lesson-parts.govuk-table')
+    end
+
+    specify "the page doesn't contain the ability to change activities" do
+      expect(page).not_to have_text('Change activity')
+    end
+  end
+end

--- a/spec/routing/teachers_lessons_routing_spec.rb
+++ b/spec/routing/teachers_lessons_routing_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe "routes for Teachers::Lessons", :type => :routing do
+  it "routes /teachers/lessons/:id/print to the widgets controller" do
+    expect(get("/teachers/lessons/1/print")).
+      to route_to("teachers/lessons#print", id: "1")
+  end
+end

--- a/spec/views/teachers/lessons/_lesson_contents.html.erb_spec.rb
+++ b/spec/views/teachers/lessons/_lesson_contents.html.erb_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "teachers/lessons/_lesson_contents" do
+  let(:lesson) { FactoryBot.build_stubbed(:lesson) }
+  let(:teacher) { FactoryBot.build_stubbed(:teacher) }
+  let!(:lesson_parts) { create_list(:lesson_part, 2, :with_activities, lesson: lesson) }
+  let(:presenter) { Teachers::LessonContentsPresenter.new(lesson, teacher) }
+
+  before :each do
+    assign(:lesson, lesson)
+    assign(:presenter, presenter)
+  end
+
+  it "includes the lesson parts" do
+    render
+    expect(rendered).to have_css('table.lesson-parts.govuk-table')
+    presenter.contents.each do |slot|
+      expect(rendered).to have_css('th.govuk-table__cell.big-number', text: slot.position)
+    end
+  end
+
+  it "doesn't show lesson parts when non are available" do
+    lesson = FactoryBot.build_stubbed(:lesson)
+    teacher = FactoryBot.build_stubbed(:teacher)
+
+    assign(:lesson, lesson)
+    assign(:presenter, Teachers::LessonContentsPresenter.new(lesson, teacher))
+
+    render
+    expect(rendered).to have_css('div.govuk-warning-text__text', text: "This lesson has no activities")
+    expect(rendered).not_to have_css('table.lesson-parts.govuk-table')
+  end
+
+  context "mode: :print" do
+    subject do
+      render "teachers/lessons/lesson_contents", { mode: :print }
+    end
+    it "omits the ability to change activities" do
+      subject
+      expect(rendered).not_to match "Change activity"
+    end
+  end
+end

--- a/spec/views/teachers/lessons/print.html.erb_spec.rb
+++ b/spec/views/teachers/lessons/print.html.erb_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "teachers/lessons/print" do
+  let(:lesson) { FactoryBot.build_stubbed(:lesson, summary: "# Big things\nwonderful") }
+  let(:teacher) { FactoryBot.build_stubbed(:teacher) }
+  let!(:lesson_parts) { create_list(:lesson_part, 2, :with_activities, lesson: lesson) }
+  let(:presenter) { Teachers::LessonContentsPresenter.new(lesson, teacher) }
+
+  before :each do
+    assign(:lesson, lesson)
+    assign(:presenter, presenter)
+  end
+
+  it "includes the lesson name" do
+    render
+    expect(rendered).to match lesson.name
+  end
+
+  it "includes the heading sections" do
+    render
+    expect(rendered).to have_css('h2', text: t(:heading, scope: :knowledge_overview))
+    expect(rendered).to have_css('h2', text: t(:heading, scope: :lesson_contents))
+  end
+
+  it "includes the lesson summary from markdown format" do
+    render
+    expect(rendered).to match markdown(lesson.summary)
+  end
+
+  it "renders partials" do
+    render
+    expect(rendered).to render_template("teachers/lessons/_core_knowledge")
+    expect(rendered).to render_template("teachers/lessons/_vocabulary")
+    expect(rendered).to render_template("teachers/lessons/_misconceptions")
+    expect(rendered).to render_template("teachers/lessons/_previous_knowledge")
+    expect(rendered).to render_template("teachers/lessons/_lesson_contents")
+  end
+end


### PR DESCRIPTION
### Context
Ticket: [CMB-67](https://dfedigital.atlassian.net/browse/CMB-67)

> DEV: As a teacher, I need to download my lesson plan, so that I can teach the lesson with fidelity

### Changes proposed in this pull request

- added a little bit of print specific CSS to remove some unwanted displayed data from the print.
- renamed the button from "Download lesson plan" to "Print lesson plan" for now as it just triggers the print action.

Following iterations from a3165ad0ba3b3e99b83d29d30a633d6c0043d586 and comments https://github.com/DFE-Digital/curriculum-materials/pull/61#pullrequestreview-359080440 a separate page for print-only display is proposed here. 

- generate a separate page to formatted for print only
- removes the dependency of JavaScript
- tested working on Chrome and Firefox
- doesn't render the "change activity" column

### Guidance to review

Display a print-ready page to allow the visitor to easily print the provided content. 

Sample: [Curriculum Materials.pdf](https://github.com/DFE-Digital/curriculum-materials/files/4213713/Curriculum.Materials.pdf)

E2E Tests: https://github.com/DFE-Digital/curriculum-materials-frontend-tests/pull/23