### PR TITLE
Dont scope activity choice by activity_id

### DIFF
--- a/app/models/activity_choice.rb
+++ b/app/models/activity_choice.rb
@@ -4,5 +4,5 @@ class ActivityChoice < ApplicationRecord
   belongs_to :lesson_part
 
   validates :teacher, :activity, :lesson_part, presence: true
-  validates :teacher_id, uniqueness: { scope: %i(activity_id lesson_part_id) }
+  validates :teacher_id, uniqueness: { scope: :lesson_part_id }
 end

--- a/db/migrate/20200217080549_remove_activity_id_from_activity_choices_index.rb
+++ b/db/migrate/20200217080549_remove_activity_id_from_activity_choices_index.rb
@@ -1,0 +1,9 @@
+class RemoveActivityIdFromActivityChoicesIndex < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :activity_choices, name: 'index_activity_choices_activity_teacher_lesson_part_ids'
+
+    safety_assured do
+      add_index :activity_choices, %i(teacher_id lesson_part_id), unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_12_080617) do
+ActiveRecord::Schema.define(version: 2020_02_17_080549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -33,9 +33,9 @@ ActiveRecord::Schema.define(version: 2020_02_12_080617) do
     t.bigint "lesson_part_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["activity_id", "teacher_id", "lesson_part_id"], name: "index_activity_choices_activity_teacher_lesson_part_ids", unique: true
     t.index ["activity_id"], name: "index_activity_choices_on_activity_id"
     t.index ["lesson_part_id"], name: "index_activity_choices_on_lesson_part_id"
+    t.index ["teacher_id", "lesson_part_id"], name: "index_activity_choices_on_teacher_id_and_lesson_part_id", unique: true
     t.index ["teacher_id"], name: "index_activity_choices_on_teacher_id"
   end
 

--- a/spec/models/activity_choice_spec.rb
+++ b/spec/models/activity_choice_spec.rb
@@ -20,8 +20,7 @@ describe ActivityChoice, type: :model do
 
     it do
       expect(create(:activity_choice)).to \
-        validate_uniqueness_of(:teacher_id).scoped_to \
-          :activity_id, :lesson_part_id
+        validate_uniqueness_of(:teacher_id).scoped_to :lesson_part_id
     end
   end
 end


### PR DESCRIPTION
Remove activity_id from the uniqueness constraint and validation.
This was preventing teachers from changing the selected activity.

Fixes #59 
