### PR TITLE
Add links to skip to next tab

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,11 @@ module ApplicationHelper
   end
 
   def cancel_button(path, text: 'Cancel')
-    link_to text, path, class: %w(govuk-button govuk-button--secondary)
+    secondary_button(path, text: text)
+  end
+
+  def secondary_button(path, text:)
+    link_to(text, path, class: %w(govuk-button govuk-button--secondary))
   end
 
   def breadcrumbs(crumbs: {}, current_page:)

--- a/app/views/teachers/lessons/show.slim
+++ b/app/views/teachers/lessons/show.slim
@@ -27,11 +27,15 @@
         = render 'misconceptions', lesson: @lesson
         = render 'previous_knowledge', lesson: @lesson
 
+        = secondary_button(teachers_lesson_path(@lesson.id, anchor: 'lesson-contents'), text: 'Lesson contents')
+
       section#lesson-contents.govuk-tabs__panel
         h2
           =t(:heading, scope: :lesson_contents)
 
         = render 'lesson_contents', lesson: @lesson
+
+        = secondary_button(teachers_lesson_path(@lesson.id, anchor: 'downloads'), text: 'Downloads')
 
       section#downloads.govuk-tabs__panel
         h2 Downloads

--- a/spec/features/lessons/downloads_tab_spec.rb
+++ b/spec/features/lessons/downloads_tab_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.feature "Downloads tab", type: :feature do
+  include_context 'logged in teacher'
+
+  let(:lesson) { FactoryBot.create(:lesson) }
+
+  before { visit(teachers_lesson_path(lesson)) }
+
+  specify %(the tab's main heading should be 'Downloads') do
+    within('#downloads') { expect(page).to have_css('h2', text: 'Downloads') }
+  end
+
+  specify %(there should be a 'Print lesson plan' link) do
+    within('#downloads') { expect(page).to have_link('Print lesson plan') }
+  end
+
+  specify %(there should be a 'Download teacher resources' link) do
+    within('#downloads') { expect(page).to have_link('Download teacher resources') }
+  end
+
+  specify %(there should be a 'Download pupil resources' link) do
+    within('#downloads') { expect(page).to have_link('Download pupil resources') }
+  end
+
+  specify %(there should be a 'Plan the next lesson' button) do
+    expect(page).to have_link('Plan the next lesson', href: '#', class: 'govuk-button')
+  end
+end

--- a/spec/features/lessons/knowledge_overview_tab_spec.rb
+++ b/spec/features/lessons/knowledge_overview_tab_spec.rb
@@ -38,7 +38,13 @@ RSpec.feature "Knowledge overview tab", type: :feature do
     ].flatten.each { |value| expect(page).to have_content(value) }
   end
 
-  specify %(there should be a 'Plan the next lesson' button) do
-    expect(page).to have_link('Plan the next lesson', href: '#', class: 'govuk-button')
+  specify 'there should be a secondary button link to the lesson contents tab' do
+    within('#knowledge-overview') do
+      expect(page).to have_link(
+        'Lesson contents',
+        href: teachers_lesson_path(lesson.id, anchor: 'lesson-contents'),
+        class: 'govuk-button--secondary'
+      )
+    end
   end
 end

--- a/spec/features/lessons/lesson_contents_tab_spec.rb
+++ b/spec/features/lessons/lesson_contents_tab_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Lesson contents tab", type: :feature do
 
   before do
     visit(teachers_lesson_path(lesson))
-    click_on 'Lesson contents'
+    within('ul.govuk-tabs__list') { click_on 'Lesson contents' }
   end
 
   specify 'the page should contain a table of lesson parts' do
@@ -29,6 +29,16 @@ RSpec.feature "Lesson contents tab", type: :feature do
       lesson_parts.each do |lesson_part|
         expect(page).to have_link('Change activity', href: new_teachers_lesson_part_choice_path(lesson_part.id))
       end
+    end
+  end
+
+  specify 'there should be a secondary button link to the downloads tab' do
+    within('#lesson-contents') do
+      expect(page).to have_link(
+        'Downloads',
+        href: teachers_lesson_path(lesson.id, anchor: 'downloads'),
+        class: 'govuk-button--secondary'
+      )
     end
   end
 end


### PR DESCRIPTION
### Context

It is likely that some lessons will have long descriptions and plenty of metadata which might make tabs long. Users could _forget_ they're inside a tab, these links provide an easier way of moving to the next one than scrolling all the way back up

### Changes proposed in this pull request

Add links, styled as secondary buttons, to the bottom of the tabs

| Before | After |
| ------ | ------ |
|  ![Screenshot from 2020-02-20 09-38-01](https://user-images.githubusercontent.com/128088/74920887-c90d2a00-53c4-11ea-934c-0426bcf037d9.png) | ![Screenshot from 2020-02-20 09-37-06](https://user-images.githubusercontent.com/128088/74920899-cca0b100-53c4-11ea-9f2a-9cc7edc33b39.png) |

### Guidance to review

Ensure it looks sensible and works

