### PR TITLE
Remove Turbolinks due to GOV.UK Tabs bug

### DIFF
--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -3,9 +3,7 @@ require.context('../images', true);
 
 import '../styles/application.scss';
 import Rails from 'rails-ujs';
-import Turbolinks from 'turbolinks';
 import { initAll } from 'govuk-frontend';
 
 Rails.start();
-Turbolinks.start();
 initAll();

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "govuk-frontend": "^3.4.0",
     "rails-ujs": "^5.2.4",
     "serialize-javascript": "^2.1.1",
-    "set-value": "^3.0.1",
-    "turbolinks": "^5.2.0"
+    "set-value": "^3.0.1"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6910,11 +6910,6 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turbolinks@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
-  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
-
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"


### PR DESCRIPTION
Turbolinks appears to cause a bug when used in conjunction with the GOV.UK Design System tabs. When both are used, the contents of all tabs are rendered inline on the page.

It would appear that this is caused by the initialisation of tabs not being triggered by `turbolinks:load` :disappointed: 

