### PR TITLE
Add more example seeds

### DIFF
--- a/app/controllers/api/v1/units_controller.rb
+++ b/app/controllers/api/v1/units_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::UnitsController < Api::BaseController
 private
 
   def unit_params
-    params.require(:unit).permit(:name, :overview, :benefits)
+    params.require(:unit).permit(:name, :overview, :benefits, :position)
   end
 
   def serialize(unit)

--- a/app/serializers/unit_serializer.rb
+++ b/app/serializers/unit_serializer.rb
@@ -6,7 +6,7 @@ class UnitSerializer
 
   adapter SimpleAMS::Adapters::AMS, root: false
 
-  fields :id, :name, :overview, :benefits
+  fields :id, :name, :overview, :benefits, :position
 
   belongs_to :complete_curriculum_programme, serializer: CompleteCurriculumProgrammeSerializer
   has_many :lessons, serializer: LessonSerializer

--- a/app/views/teachers/lessons/_vocabulary.slim
+++ b/app/views/teachers/lessons/_vocabulary.slim
@@ -1,8 +1,9 @@
-section.vocabulary
-  h2.govuk-heading-m Vocabulary
+- if lesson.vocabulary.present?
+  section.vocabulary
+    h2.govuk-heading-m Vocabulary
 
-  p By the end of the lesson pupils should know the words:
+    p By the end of the lesson pupils should know the words:
 
-  ul
-    - lesson.vocabulary.each do |word|
-      li = word
+    ul
+      - lesson.vocabulary.each do |word|
+        li = word

--- a/db/migrate/20200123103019_create_units.rb
+++ b/db/migrate/20200123103019_create_units.rb
@@ -6,6 +6,7 @@ class CreateUnits < ActiveRecord::Migration[6.0]
       t.string :name, null: false, limit: 256
       t.string :overview, null: false, limit: 1024
       t.text :benefits, null: false
+      t.integer :position
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 2020_02_21_144353) do
     t.string "name", limit: 256, null: false
     t.string "overview", limit: 1024, null: false
     t.text "benefits", null: false
+    t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["complete_curriculum_programme_id"], name: "index_units_on_complete_curriculum_programme_id"

--- a/db/seeds/data/history/the-norman-invasion/the-battle-of-hastings.yml
+++ b/db/seeds/data/history/the-norman-invasion/the-battle-of-hastings.yml
@@ -1,4 +1,5 @@
 unit:
+  position: 1
   name: The battle of Hastings
   overview: |-
     In 1002 Ethelred King of England married Emma, the sister of Richard II, Duke

--- a/db/seeds/data/history/the-norman-invasion/the-battle-of-hastings/harolds-march-south.yml
+++ b/db/seeds/data/history/the-norman-invasion/the-battle-of-hastings/harolds-march-south.yml
@@ -1,0 +1,65 @@
+lesson:
+  name: Harold's march south
+  position: 3
+  misconceptions:
+    - The Normans built Britain's first castles
+  vocabulary:
+    - Vikings
+    - Normans
+  core_knowledge: |-
+    In early 1066, Harold's exiled brother Tostig Godwinson raided southeastern
+    England with a fleet he had recruited in Flanders, later joined by other
+    ships from Orkney. Threatened by Harold's fleet, Tostig moved north and
+    raided in East Anglia and Lincolnshire. He was driven back to his ships by
+    the brothers Edwin, Earl of Mercia and Morcar, Earl of Northumbria.
+
+    Deserted by most of his followers, he withdrew to Scotland, where he spent
+    the middle of the year recruiting fresh forces. Hardrada invaded
+    northern England in early September, leading a fleet of more than 300 ships
+    carrying perhaps 15,000 men. Hardrada's army was further augmented by the
+    forces of Tostig, who supported the Norwegian king's bid for the throne.
+    Advancing on York, the Norwegians occupied the city after defeating a
+    northern English army under Edwin and Morcar on 20 September at the Battle
+    of Fulford.
+
+  summary: |-
+    After defeating his brother Tostig and Harald Hardrada in the north, Harold
+    left much of his forces in the north, including Morcar and Edwin, and
+    marched the rest of his army south to deal with the threatened Norman
+    invasion. It is unclear when Harold learned of William's landing, but it
+    was probably while he was travelling south. Harold stopped in London, and
+    was there for about a week before Hastings, so it is likely that he spent
+    about a week on his march south, averaging about 27 miles per day, for the
+    approximately 200 miles.
+
+    Harold camped at Caldbec Hill on the night of 13 October, near what was
+    described as a "hoar-apple tree". This location was about 8 miles (13
+    kilometres) from William's castle at Hastings. Some of the early
+    contemporary French accounts mention an emissary or emissaries sent by
+    Harold to William, which is likely. Nothing came of these efforts.
+
+    Although Harold attempted to surprise the Normans, William's scouts
+    reported the English arrival to the duke. The exact events preceding the
+    battle are obscure, with contradictory accounts in the sources, but all
+    agree that William led his army from his castle and advanced towards the
+    enemy. Harold had taken a defensive position at the top of Senlac Hill
+    (present-day Battle, East Sussex), about 6 miles (9.7 kilometres) from
+    William's castle at Hastings.
+
+  previous_knowledge:
+    Harald Sigurdsson: |-
+      Also known as Harald of Norway (Old Norse: Haraldr Sigurðarson; c. 1015 –
+      25 September 1066) and given the epithet Hardrada (Old Norse: harðráði,
+      modern Norwegian: Hardråde, roughly translated as "stern counsel" or
+      "hard ruler") in the sagas, was King of Norway (as Harald III) from
+      1046 to 1066. In addition, he unsuccessfully claimed the Danish throne
+      until 1064 and the English throne in 1066. Before becoming king, Harald
+      had spent around fifteen years in exile as a mercenary and military
+      commander in Kievan Rus' and of the Varangian Guard in the Byzantine
+      Empire.
+
+    Tostig Godwinson: |-
+      Tostig Godwinson was an Anglo-Saxon Earl of Northumbria and brother of
+      King Harold Godwinson. After being exiled by his brother, Tostig
+      supported the Norwegian king Harald Hardrada's invasion of England, and
+      was killed at the Battle of Stamford Bridge in 1066.

--- a/db/seeds/data/history/the-norman-invasion/the-battle-of-hastings/norman-preparations-and-forces.yml
+++ b/db/seeds/data/history/the-norman-invasion/the-battle-of-hastings/norman-preparations-and-forces.yml
@@ -1,0 +1,58 @@
+lesson:
+  name: Norman preparations and forces
+  position: 1
+  misconceptions:
+    - The Normans built Britain's first castles
+    - All Britains were free before the Norman Conquest. Prior to 1066, 10%
+      of the population were slaves
+  vocabulary:
+    - Vikings
+    - Normans
+    - Gentry
+  core_knowledge: |-
+    In the course of the 10th century, the initially destructive incursions of
+    Norse war bands going upstream into the rivers of France penetrated further
+    into interior Europe, and evolved into more permanent encampments that
+    included local French women and personal property.
+  summary: |-
+    William assembled a large invasion fleet and an army gathered from
+    Normandy and all over France, including large contingents from Brittany
+    and Flanders. He mustered his forces at Saint-Valery-sur-Somme and was
+    ready to cross the Channel by about 12 August. The exact numbers and
+    composition of William's force are unknown. A contemporary document
+    claims that William had 726 ships, but this may be an inflated figure.
+    Figures given by contemporary writers are highly exaggerated, varying
+    from 14,000 to 150,000 men.
+
+    Modern historians have offered a range of estimates for the size of
+    William's forces; 7000–8000 men, 1000–2000 of them cavalry; 10,000–12,000
+    men; 10,000 men, 3000 of them cavalry; or 7500 men. The army would have
+    consisted of a mix of cavalry, infantry, and archers or crossbowmen, with
+    about equal numbers of cavalry and archers and the foot soldiers equal in
+    number to the other two types combined.  Although later lists of
+    companions of William the Conqueror are extant, most are padded with
+    extra names; only about 35 individuals can be reliably claimed to have
+    been with William at Hastings.
+
+    William of Poitiers states that William obtained Pope Alexander II's consent
+    for the invasion, signified by a papal banner, along with diplomatic support
+    from other European rulers. Although Alexander did give papal approval to the
+    conquest after it succeeded, no other source claims papal support before the
+    invasion.[f] William's army assembled during the summer while an invasion fleet
+    in Normandy was constructed. Although the army and fleet were ready by early
+    August, adverse winds kept the ships in Normandy until late September. There
+    were probably other reasons for William's delay, including intelligence reports
+    from England revealing that Harold's forces were deployed along the coast.
+    William would have preferred to delay the invasion until he could make an
+    unopposed landing
+
+  previous_knowledge:
+    The Battle of Stamford Bridge: |-
+      The Battle of Stamford Bridge took place at the village of Stamford
+      Bridge, East Riding of Yorkshire, in England on 25 September 1066,
+      between an English army under King Harold Godwinson and an invading
+      Norwegian force led by King Harald Hardrada and the English king's
+      brother Tostig Godwinson
+
+    Types of soldier: |-
+      Pupils should be aware of cavalry, infantry, archers and crossbowmen.

--- a/db/seeds/data/history/the-norman-invasion/the-battle-of-hastings/prelude-to-the-battle.yml
+++ b/db/seeds/data/history/the-norman-invasion/the-battle-of-hastings/prelude-to-the-battle.yml
@@ -1,10 +1,10 @@
 lesson:
   name: Prelude to the battle
-
+  position: 2
+  vocabulary: []
   misconceptions:
     - Historians know exactly where and when the battle took place
     - Harold Godwinson was killed by an arrow in the eye
-
   core_knowledge: |-
     When William heard the news that Harold had become king his reaction was
     swift. He called a meeting of his greatest men.  William made plans to gather
@@ -28,7 +28,6 @@ lesson:
     Harold also received news that William had landed at
     Pevensey and came south as quickly as he could. The king rested at London for
     a few days before taking his army to meet William and his French forces.
-
   summary: |-
     On 12 September 1066 William's fleet sailed from Normandy.  Several ships
     sank in storms, which forced the fleet to take shelter at
@@ -44,7 +43,6 @@ lesson:
     was killed and his forces defeated. His brothers Gyrth and Leofwine were
     also killed in the battle, according to the Anglo-Saxon
     Chronicle.
-
   previous_knowledge:
     Who was Harold Godwinson?: |-
         Harold was a son of Godwin (c. 1001–1053), the powerful Earl of

--- a/db/seeds/seeders/lesson_seeder.rb
+++ b/db/seeds/seeders/lesson_seeder.rb
@@ -3,15 +3,17 @@ module Seeders
     attr_accessor :id, :name, :misconceptions, :core_knowledge,
                   :summary, :previous_knowledge
 
-    def initialize(ccp, unit, name:, misconceptions:, core_knowledge:, summary:, previous_knowledge:)
+    def initialize(ccp, unit, name:, misconceptions:, core_knowledge:, summary:, previous_knowledge:, vocabulary:, position:)
       @ccp  = ccp
       @unit = unit
 
-      @name               = name
-      @misconceptions     = misconceptions
       @core_knowledge     = core_knowledge
-      @summary            = summary
+      @misconceptions     = misconceptions
+      @name               = name
+      @position           = position
       @previous_knowledge = previous_knowledge
+      @summary            = summary
+      @vocabulary         = vocabulary
     end
 
     def identifier
@@ -38,7 +40,8 @@ module Seeders
         misconceptions: @misconceptions,
         name: @name,
         previous_knowledge: @previous_knowledge,
-        summary: @summary
+        summary: @summary,
+        vocabulary: @vocabulary
       }
     end
 

--- a/db/seeds/seeders/unit_seeder.rb
+++ b/db/seeds/seeders/unit_seeder.rb
@@ -1,13 +1,14 @@
 module Seeders
   class UnitSeeder < BaseSeeder
-    attr_accessor :id, :name, :overview, :benefits
+    attr_accessor :id, :name, :overview, :benefits, :position
 
-    def initialize(ccp, name:, overview:, benefits:)
+    def initialize(ccp, name:, overview:, benefits:, position:)
       @ccp = ccp
 
       @name     = name
       @overview = overview
       @benefits = benefits
+      @position = position
     end
 
     def identifier
@@ -29,7 +30,7 @@ module Seeders
     end
 
     def attributes
-      { name: @name, overview: @overview, benefits: @benefits }
+      { name: @name, overview: @overview, benefits: @benefits, position: @position }
     end
 
     def payload

--- a/spec/factories/unit.rb
+++ b/spec/factories/unit.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     association(:complete_curriculum_programme, factory: :ccp)
     overview { "Overview" }
     benefits { "Benefits" }
+    sequence(:position) { |n| n }
 
     trait(:randomised) do
       name { Faker::Lorem.word.capitalize }

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Unit, type: :model do
     it { is_expected.to have_db_column(:name).of_type(:string) }
     it { is_expected.to have_db_column(:overview).of_type(:string) }
     it { is_expected.to have_db_column(:benefits).of_type(:text) }
+    it { is_expected.to have_db_column(:position).of_type(:integer) }
   end
 
   describe 'validation' do

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -36,9 +36,10 @@ RSpec.configure do |config|
             properties: {
               name: { type: :string },
               benefits: { type: :string },
-              overview: { type: :string }
+              overview: { type: :string },
+              position: { type: :integer }
             },
-            required: %i(name benefits overview)
+            required: %i(name benefits overview position)
           },
           lesson: {
             type: :object,


### PR DESCRIPTION
This started off as an attempt to add more seed data, there were two minor flaws uncovered in the process so they're fixed here too

* Add position to `Unit`
* Add vocabulary to the `LessonSeeder`, it was accidentally left out of #62 

Now the lesson page looks a little less bare:

![Screenshot from 2020-02-24 09-54-25](https://user-images.githubusercontent.com/128088/75142941-0981e600-56ec-11ea-86ef-189f3df2558a.png)
