### PR TITLE
Add teaching methods functionality to api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem "strong_migrations", "~> 0.5"
 gem "slim-rails"
 gem "redcarpet"
 gem "sentry-raven"
-gem "simple_ams"
 gem "blueprinter"
 gem "actionview-component"
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,6 @@ GEM
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
-    simple_ams (0.2.3)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -361,7 +360,6 @@ DEPENDENCIES
   scss_lint-govuk
   sentry-raven
   shoulda-matchers (~> 4.1)
-  simple_ams
   simplecov
   slim-rails
   spring

--- a/app/controllers/api/v1/teaching_methods_controller.rb
+++ b/app/controllers/api/v1/teaching_methods_controller.rb
@@ -1,0 +1,25 @@
+class Api::V1::TeachingMethodsController < Api::BaseController
+  def index
+    render(
+      json: SimpleAMS::Renderer::Collection.new(
+        TeachingMethod.all,
+        serializer: TeachingMethodSerializer,
+        includes: []
+      ).to_json
+    )
+  end
+
+  def show
+    teaching_method = TeachingMethod.find(params[:id])
+
+    render(
+      json: SimpleAMS::Renderer.new(
+        teaching_method,
+        serializer: TeachingMethodSerializer,
+        includes: []
+      ).to_json
+    )
+  rescue ActiveRecord::RecordNotFound
+    render(json: { errors: %(Teaching method #{params[:id]} not found) }, status: :not_found)
+  end
+end

--- a/app/serializers/activity_serializer.rb
+++ b/app/serializers/activity_serializer.rb
@@ -6,4 +6,5 @@ class ActivitySerializer
   fields :id, :name, :overview, :duration, :default, :extra_requirements
 
   belongs_to :lesson_part, serializer: LessonPartSerializer
+  has_many :teaching_methods, serializer: TeachingMethodSerializer
 end

--- a/app/serializers/teaching_method_serializer.rb
+++ b/app/serializers/teaching_method_serializer.rb
@@ -1,0 +1,9 @@
+class TeachingMethodSerializer
+  include SimpleAMS::DSL
+
+  adapter SimpleAMS::Adapters::AMS, root: false
+
+  fields :id, :name, :icon, :description
+
+  has_many :activities, serializer: ActivitySerializer
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,8 @@ Rails.application.routes.draw do
           end
         end
       end
+
+      resources :teaching_methods, only: %i(index show)
     end
   end
 end

--- a/db/seeds/seeder.rb
+++ b/db/seeds/seeder.rb
@@ -57,8 +57,10 @@ def log_progress(msg, indent = 0)
   puts((" " * indent) + msg)
 end
 
-def extract_attributes(file, key)
-  YAML.load_file(file)[key].symbolize_keys
+def extract_attributes(file, key, symbolize_keys = true)
+  attributes = YAML.load_file(file)[key]
+
+  symbolize_keys ? attributes.symbolize_keys : attributes
 end
 
 def descendents(origin, matcher = "*.yml")
@@ -96,7 +98,9 @@ unless Rails.env.test?
 
                   # Fifth, activities
                   descendents(lesson_part_directory).each do |activity_file|
-                    Seeders::ActivitySeeder.new(ccp, unit, lesson, lesson_part, **extract_attributes(activity_file, 'activity')).tap do |activity|
+                    teaching_methods = extract_attributes(activity_file, 'teaching_methods', false)
+
+                    Seeders::ActivitySeeder.new(ccp, unit, lesson, lesson_part, **extract_attributes(activity_file, 'activity').merge(teaching_methods: teaching_methods)).tap do |activity|
                       log_progress("Saving activity: #{activity.name}", 4)
 
                       # TODO add teaching methods

--- a/db/seeds/seeders/activity_seeder.rb
+++ b/db/seeds/seeders/activity_seeder.rb
@@ -2,7 +2,7 @@ module Seeders
   class ActivitySeeder < BaseSeeder
     attr_accessor :id, :name, :overview, :duration, :extra_requirements
 
-    def initialize(ccp, unit, lesson, lesson_part, name:, overview:, duration:, extra_requirements:)
+    def initialize(ccp, unit, lesson, lesson_part, name:, overview:, duration:, extra_requirements:, teaching_methods: [])
       @ccp         = ccp
       @unit        = unit
       @lesson      = lesson
@@ -12,6 +12,8 @@ module Seeders
       @overview           = overview
       @duration           = duration
       @extra_requirements = extra_requirements
+
+      @teaching_methods = teaching_methods
     end
 
     def identifier
@@ -49,7 +51,18 @@ module Seeders
     end
 
     def payload
-      { activity: attributes }
+      { activity: attributes, teaching_methods: @teaching_methods }
+    end
+
+    def teaching_method_objects
+      TeachingMethod.where(name: @teaching_methods)
+    end
+
+    def save_via_model
+      model_class.create!(attributes.merge(parent)).tap do |obj|
+        @id = obj.id
+        obj.teaching_methods << teaching_method_objects
+      end
     end
   end
 end

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -121,6 +121,12 @@
           }
         }
       },
+      "teaching_methods": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
       "teaching_method": {
         "type": "object",
         "properties": {
@@ -268,6 +274,9 @@
                     "required": [
                       "activity"
                     ]
+                  },
+                  "teaching_methods": {
+                    "$ref": "#/components/schemas/teaching_methods"
                   }
                 }
               }
@@ -287,7 +296,21 @@
                     "PVA Glue",
                     "Glitter"
                   ],
-                  "default": true
+                  "default": true,
+                  "teaching_methods": [
+                    {
+                      "name": "Teaching method 1",
+                      "icon": "teaching-method-1",
+                      "description": "Teaching method description 1",
+                      "id": 1
+                    },
+                    {
+                      "name": "Teaching method 2",
+                      "icon": "teaching-method-2",
+                      "description": "Teaching method description 2",
+                      "id": 2
+                    }
+                  ]
                 }
               }
             }
@@ -359,7 +382,21 @@
                   "Glitter"
                 ],
                 "default": false,
-                "id": 1
+                "id": 1,
+                "teaching_methods": [
+                  {
+                    "name": "Teaching method 3",
+                    "icon": "teaching-method-3",
+                    "description": "Teaching method description 3",
+                    "id": 1
+                  },
+                  {
+                    "name": "Teaching method 4",
+                    "icon": "teaching-method-4",
+                    "description": "Teaching method description 4",
+                    "id": 2
+                  }
+                ]
               }
             },
             "content": {
@@ -430,6 +467,9 @@
                     "required": [
                       "activity"
                     ]
+                  },
+                  "teaching_methods": {
+                    "$ref": "#/components/schemas/teaching_methods"
                   }
                 }
               }
@@ -449,7 +489,21 @@
                     "PVA Glue",
                     "Glitter"
                   ],
-                  "default": false
+                  "default": false,
+                  "teaching_methods": [
+                    {
+                      "name": "Teaching method 5",
+                      "icon": "teaching-method-5",
+                      "description": "Teaching method description 5",
+                      "id": 1
+                    },
+                    {
+                      "name": "Teaching method 6",
+                      "icon": "teaching-method-6",
+                      "description": "Teaching method description 6",
+                      "id": 2
+                    }
+                  ]
                 }
               }
             }
@@ -1218,9 +1272,9 @@
             "description": "all teaching methods found",
             "examples": {
               "application/json": {
-                "name": "Teaching method 1",
-                "icon": "teaching-method-1",
-                "description": "Teaching method description 1",
+                "name": "Teaching method 7",
+                "icon": "teaching-method-7",
+                "description": "Teaching method description 7",
                 "id": 1
               }
             },
@@ -1259,9 +1313,9 @@
             "description": "with a valid id",
             "examples": {
               "application/json": {
-                "name": "Teaching method 2",
-                "icon": "teaching-method-2",
-                "description": "Teaching method description 2",
+                "name": "Teaching method 8",
+                "icon": "teaching-method-8",
+                "description": "Teaching method description 8",
                 "id": 1
               }
             },
@@ -1277,9 +1331,9 @@
             "description": "with a bad id",
             "examples": {
               "application/json": {
-                "name": "Teaching method 3",
-                "icon": "teaching-method-3",
-                "description": "Teaching method description 3",
+                "name": "Teaching method 9",
+                "icon": "teaching-method-9",
+                "description": "Teaching method description 9",
                 "id": 1
               }
             },

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -104,6 +104,9 @@
           "id": {
             "type": "integer"
           },
+          "name": {
+            "type": "string"
+          },
           "overview": {
             "type": "string"
           },
@@ -115,6 +118,17 @@
             "items": {
               "type": "string"
             }
+          }
+        }
+      },
+      "teaching_method": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
           }
         }
       }
@@ -168,21 +182,25 @@
             "examples": {
               "application/json": [
                 {
+                  "name": "Activity 1",
                   "overview": "Overview 1",
                   "duration": 20,
                   "extra_requirements": [
                     "PVA Glue",
                     "Glitter"
                   ],
+                  "default": false,
                   "id": 1
                 },
                 {
+                  "name": "Activity 2",
                   "overview": "Overview 2",
                   "duration": 20,
                   "extra_requirements": [
                     "PVA Glue",
                     "Glitter"
                   ],
+                  "default": false,
                   "id": 2
                 }
               ]
@@ -262,12 +280,14 @@
             "examples": {
               "application/json": {
                 "activity": {
+                  "name": "Activity 3",
                   "overview": "Overview 3",
                   "duration": 20,
                   "extra_requirements": [
                     "PVA Glue",
                     "Glitter"
-                  ]
+                  ],
+                  "default": true
                 }
               }
             }
@@ -331,12 +351,14 @@
             "description": "activity found",
             "examples": {
               "application/json": {
+                "name": "Activity 4",
                 "overview": "Overview 4",
                 "duration": 20,
                 "extra_requirements": [
                   "PVA Glue",
                   "Glitter"
                 ],
+                "default": false,
                 "id": 1
               }
             },
@@ -420,12 +442,14 @@
             "examples": {
               "application/json": {
                 "activity": {
+                  "name": "Activity 5",
                   "overview": "Overview 5",
                   "duration": 20,
                   "extra_requirements": [
                     "PVA Glue",
                     "Glitter"
-                  ]
+                  ],
+                  "default": false
                 }
               }
             }
@@ -1179,6 +1203,93 @@
           },
           "400": {
             "description": "invalid lesson"
+          }
+        }
+      }
+    },
+    "/teaching_methods": {
+      "get": {
+        "summary": "retrieves all teaching methods",
+        "tags": [
+          "TeachingMethod"
+        ],
+        "responses": {
+          "200": {
+            "description": "all teaching methods found",
+            "examples": {
+              "application/json": {
+                "name": "Teaching method 1",
+                "icon": "teaching-method-1",
+                "description": "Teaching method description 1",
+                "id": 1
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/teaching_method"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teaching_methods/{id}": {
+      "get": {
+        "summary": "retrieves the specified teaching method",
+        "tags": [
+          "TeachingMethod"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "with a valid id",
+            "examples": {
+              "application/json": {
+                "name": "Teaching method 2",
+                "icon": "teaching-method-2",
+                "description": "Teaching method description 2",
+                "id": 1
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/teaching_method"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "with a bad id",
+            "examples": {
+              "application/json": {
+                "name": "Teaching method 3",
+                "icon": "teaching-method-3",
+                "description": "Teaching method description 3",
+                "id": 1
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/teaching_method"
+                }
+              }
+            }
           }
         }
       }

--- a/spec/controllers/api/v1/activities_controller_spec.rb
+++ b/spec/controllers/api/v1/activities_controller_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::ActivitiesController, type: :request do
+  let(:new_activity_name) { "Maths quiz" }
+
+  describe '#create' do
+    let(:lesson_part) { create(:lesson_part) }
+    let(:lesson) { lesson_part.lesson }
+    let(:unit) { lesson.unit }
+    let(:ccp) { unit.complete_curriculum_programme }
+
+    let(:path_args) { [ccp, unit, lesson, lesson_part] }
+
+    subject do
+      post(api_v1_ccp_unit_lesson_lesson_part_activities_path(*path_args, activity_params))
+    end
+
+    context 'when no teaching methods are provided' do
+      let(:activity_params) { { activity: attributes_for(:activity) } }
+
+      specify 'should create the activity with no teaching methods' do
+        expect(subject).to be(201)
+        expect(Activity.last.teaching_methods).to be_empty
+      end
+    end
+
+    context 'when some teaching methods are provided' do
+      let(:number_of_teaching_methods) { 2 }
+      let(:teaching_methods) { create_list(:teaching_method, number_of_teaching_methods) }
+
+      let(:activity_params) do
+        {
+          activity: attributes_for(:activity),
+          teaching_methods: teaching_methods.map(&:name)
+        }
+      end
+
+      specify 'should create the activity successfully with teaching methods attached' do
+        expect(subject).to be(201)
+        expect(Activity.last.teaching_methods.count).to eql(number_of_teaching_methods)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:number_of_teaching_methods) { 2 }
+
+    let(:activity) { create(:activity) }
+    let(:lesson_part) { activity.lesson_part }
+    let(:lesson) { lesson_part.lesson }
+    let(:unit) { lesson.unit }
+    let(:ccp) { unit.complete_curriculum_programme }
+
+    let(:existing_teaching_methods) { create_list(:teaching_method, number_of_teaching_methods) }
+    before { activity.teaching_methods << existing_teaching_methods }
+
+    let(:path_args) { [ccp, unit, lesson, lesson_part, activity] }
+
+    subject do
+      patch(api_v1_ccp_unit_lesson_lesson_part_activity_path(*path_args, activity_params))
+    end
+
+    context 'when an empty array of teaching methods is provided' do
+      let(:activity_params) do
+        {
+          activity: { name: new_activity_name },
+          teaching_methods: []
+        }
+      end
+
+      specify 'should update the activity name' do
+        subject
+        expect(activity.reload.name).to eql(new_activity_name)
+      end
+
+      specify 'should clear the existing teaching methods' do
+        expect(activity.teaching_methods).to match_array(existing_teaching_methods)
+        expect(subject).to be(200)
+        expect(activity.reload.teaching_methods).to be_empty
+      end
+    end
+
+    context 'when an new array of teaching methods is provided' do
+      let(:new_teaching_methods) { create_list(:teaching_method, number_of_teaching_methods) }
+
+      let(:activity_params) do
+        {
+          activity: { name: new_activity_name },
+          teaching_methods: new_teaching_methods.map(&:name)
+        }
+      end
+
+      specify 'should update the activity name' do
+        subject
+        expect(activity.reload.name).to eql(new_activity_name)
+      end
+
+      specify 'should assign the provided teaching methods' do
+        expect(activity.teaching_methods).to match_array(existing_teaching_methods)
+        expect(subject).to be(200)
+        expect(activity.reload.teaching_methods).to match_array(new_teaching_methods)
+      end
+    end
+
+    context 'when an new array of teaching methods is provided' do
+      let(:activity_params) { { activity: { name: new_activity_name } } }
+
+      specify 'should update the activity' do
+        subject
+        expect(activity.reload.name).to eql(new_activity_name)
+      end
+
+      specify 'should not change the existing teaching methods' do
+        expect(activity.teaching_methods).to match_array(existing_teaching_methods)
+        expect(subject).to be(200)
+        expect(activity.teaching_methods).to match_array(existing_teaching_methods)
+      end
+    end
+  end
+end

--- a/spec/factories/teaching_methods.rb
+++ b/spec/factories/teaching_methods.rb
@@ -1,10 +1,12 @@
 FactoryBot.define do
   factory :teaching_method do
     sequence(:name) { |n| "Teaching method #{n}" }
+    sequence(:icon) { |n| "teaching-method-#{n}" }
     sequence(:description) { |n| "Teaching method description #{n}" }
 
     trait(:randomised) do
       name { Faker::Lorem.sentence }
+      icon { Faker::Lorem.words.join('-').downcase }
       description { Faker::Lorem.paragraphs(number: 3).join("\n\n") }
     end
   end

--- a/spec/integration/api/v1/activities_spec.rb
+++ b/spec/integration/api/v1/activities_spec.rb
@@ -51,6 +51,9 @@ describe 'Activities' do
           properties: {
             activity: {
               '$ref' => '#/components/schemas/activity', required: %i(activity)
+            },
+            teaching_methods: {
+              '$ref' => '#/components/schemas/teaching_methods'
             }
           }
         }
@@ -65,7 +68,7 @@ describe 'Activities' do
       response(201, 'activity created') do
         let!(:activity_params) { { activity: FactoryBot.attributes_for(:activity, default: true) } }
 
-        examples('application/json': { activity: FactoryBot.attributes_for(:activity, default: true) })
+        examples('application/json': { activity: FactoryBot.attributes_for(:activity, default: true).merge(teaching_methods: example_teaching_methods(2)) })
 
         run_test! do |response|
           JSON.parse(response.body).with_indifferent_access.tap do |json|
@@ -106,7 +109,7 @@ describe 'Activities' do
       parameter(name: :id, in: :path, type: :string, required: true)
 
       response('200', 'activity found') do
-        examples('application/json': example_activity)
+        examples('application/json': example_activity.merge(teaching_methods: example_teaching_methods(2)))
 
         schema('$ref' => '#/components/schemas/activity')
 
@@ -142,6 +145,9 @@ describe 'Activities' do
           properties: {
             activity: {
               '$ref' => '#/components/schemas/activity', required: %i(activity)
+            },
+            teaching_methods: {
+              '$ref' => '#/components/schemas/teaching_methods'
             }
           }
         }
@@ -150,7 +156,7 @@ describe 'Activities' do
       request_body_json(schema: { '$ref' => '#/components/schemas/activity' })
 
       response(200, 'activity updated') do
-        examples('application/json': { activity: FactoryBot.attributes_for(:activity) })
+        examples('application/json': { activity: FactoryBot.attributes_for(:activity).merge(teaching_methods: example_teaching_methods(2)) })
 
         run_test! do |response|
           JSON.parse(response.body).with_indifferent_access.tap do |json|

--- a/spec/integration/api/v1/teaching_methods_spec.rb
+++ b/spec/integration/api/v1/teaching_methods_spec.rb
@@ -1,0 +1,63 @@
+require 'swagger_helper'
+
+describe 'Teaching methods' do
+  path('/teaching_methods') do
+    get('retrieves all teaching methods') do
+      tags('TeachingMethod')
+      produces('application/json')
+
+      let!(:teaching_methods) { FactoryBot.create_list(:teaching_method, 3) }
+
+      response('200', 'all teaching methods found') do
+        examples('application/json': example_teaching_method)
+
+        schema(type: :array, items: { '$ref' => '#/components/schemas/teaching_method' })
+
+        run_test! do |response|
+          expected_names = teaching_methods.map(&:name)
+          actual_names = JSON.parse(response.body).map { |tm| tm.dig('name') }
+
+          expect(actual_names).to match_array(expected_names)
+        end
+      end
+    end
+  end
+
+  path('/teaching_methods/{id}') do
+    get('retrieves the specified teaching method') do
+      tags('TeachingMethod')
+      produces('application/json')
+
+      let!(:teaching_method) { FactoryBot.create(:teaching_method) }
+
+      parameter(name: :id, in: :path, type: :string, required: true)
+
+      response('200', 'with a valid id') do
+        examples('application/json': example_teaching_method)
+        let(:id) { teaching_method.id }
+
+        schema('$ref' => '#/components/schemas/teaching_method')
+
+        run_test! do |response|
+          expected_name = teaching_method.name
+          actual_name = JSON.parse(response.body).dig('name')
+
+          expect(actual_name).to eql(expected_name)
+        end
+      end
+
+      response('404', 'with a bad id') do
+        examples('application/json': example_teaching_method)
+
+        schema('$ref' => '#/components/schemas/teaching_method')
+        let(:id) { 'magic' }
+
+        run_test! do |response|
+          expect(JSON.parse(response.body).dig('errors')).to eql(
+            %(Teaching method #{id} not found)
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/support/api_examples.rb
+++ b/spec/support/api_examples.rb
@@ -38,6 +38,14 @@ def example_activities(quantity)
   1.upto(quantity).map { |i| example_activity(i) }
 end
 
+def example_teaching_method(id = 1)
+  FactoryBot.attributes_for(:teaching_method).merge(id: id)
+end
+
+def example_teaching_methods(quantity)
+  1.upto(quantity).map { |i| teaching_method(i) }
+end
+
 def example_errors
   ["Name can't be blank"]
 end

--- a/spec/support/api_examples.rb
+++ b/spec/support/api_examples.rb
@@ -43,7 +43,7 @@ def example_teaching_method(id = 1)
 end
 
 def example_teaching_methods(quantity)
-  1.upto(quantity).map { |i| teaching_method(i) }
+  1.upto(quantity).map { |i| example_teaching_method(i) }
 end
 
 def example_errors

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -76,6 +76,9 @@ RSpec.configure do |config|
               }
             }
           },
+          teaching_methods: {
+            type: :array, items: { type: :string }
+          },
 
           # metadata
           teaching_method: {

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -75,6 +75,15 @@ RSpec.configure do |config|
                 type: :array, items: { type: :string }
               }
             }
+          },
+
+          # metadata
+          teaching_method: {
+            type: :object,
+            properties: {
+              name: { type: :string },
+              icon: { type: :string }
+            }
           }
         }
       },


### PR DESCRIPTION
Teaching methods were no longer being set by the seeds. This is because the API didn't support setting teaching methods. This changes that

* [x] Add ability to set teaching methods on creating and updating activities
* [x] Add specs covering the new behaviour
* [x] Add examples to the seeds demonstrating the new behaviour
* [x] Deal with bad teaching methods
* [x] Update Swagger definitions
