### PR TITLE
Add lesson parts lessons fk

### DIFF
--- a/db/migrate/20200226092814_add_lessson_parts_lessons_foreign_key.rb
+++ b/db/migrate/20200226092814_add_lessson_parts_lessons_foreign_key.rb
@@ -1,0 +1,7 @@
+class AddLesssonPartsLessonsForeignKey < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      add_foreign_key :lesson_parts, :lessons
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_21_144353) do
+ActiveRecord::Schema.define(version: 2020_02_26_092814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -137,6 +137,7 @@ ActiveRecord::Schema.define(version: 2020_02_21_144353) do
   add_foreign_key "activity_choices", "teachers"
   add_foreign_key "activity_teaching_methods", "activities"
   add_foreign_key "activity_teaching_methods", "teaching_methods"
+  add_foreign_key "lesson_parts", "lessons"
   add_foreign_key "lessons", "units"
   add_foreign_key "units", "complete_curriculum_programmes"
 end

--- a/spec/views/teachers/lessons/_lesson_contents.slim_spec.rb
+++ b/spec/views/teachers/lessons/_lesson_contents.slim_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "teachers/lessons/_lesson_contents" do
-  let(:lesson) { FactoryBot.build_stubbed(:lesson) }
-  let(:teacher) { FactoryBot.build_stubbed(:teacher) }
-  let!(:lesson_parts) { create_list(:lesson_part, 2, :with_activities, lesson: lesson) }
+  let(:lesson) { FactoryBot.create(:lesson) }
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let!(:lesson_parts) { FactoryBot.create_list(:lesson_part, 2, :with_activities, lesson: lesson) }
   let(:presenter) { Teachers::LessonContentsPresenter.new(lesson, teacher) }
 
   before :each do

--- a/spec/views/teachers/lessons/print.slim_spec.rb
+++ b/spec/views/teachers/lessons/print.slim_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "teachers/lessons/print" do
-  let(:lesson) { FactoryBot.build_stubbed(:lesson, summary: "# Big things\nwonderful") }
-  let(:teacher) { FactoryBot.build_stubbed(:teacher) }
-  let!(:lesson_parts) { create_list(:lesson_part, 2, :with_activities, lesson: lesson) }
+  let(:lesson) { FactoryBot.create(:lesson, summary: "# Big things\nwonderful") }
+  let(:teacher) { FactoryBot.create(:teacher) }
+  let!(:lesson_parts) { FactoryBot.create_list(:lesson_part, 2, :with_activities, lesson: lesson) }
   let(:presenter) { Teachers::LessonContentsPresenter.new(lesson, teacher) }
 
   before :each do


### PR DESCRIPTION
### Context

When generating a ER diagram I noticed there wasn't a FK between `lessons` and `lesson_parts`.

### Changes proposed in this pull request

Add the missing FK. Also, fix a couple of test failures caused by the change

### Guidance to review

Ensure it makes sense
