### PR TITLE
Cmb 476/add uploads to api

### DIFF
--- a/app/controllers/api/v1/pupil_resources_controller.rb
+++ b/app/controllers/api/v1/pupil_resources_controller.rb
@@ -1,9 +1,5 @@
 class Api::V1::PupilResourcesController < Api::BaseController
   def index
-    activity = Activity.find_by! id: params[:activity_id]
-
-    pupil_resources = activity.pupil_resources
-
     render json: SimpleAMS::Renderer::Collection.new(
       pupil_resources,
       serializer: PupilResourceSerializer,
@@ -12,16 +8,28 @@ class Api::V1::PupilResourcesController < Api::BaseController
   end
 
   def create
-    activity = Activity.find_by! id: params[:activity_id]
-
-    if activity.pupil_resources.attach pupil_resource_params
+    if pupil_resources.attach pupil_resource_params
       head :created
     else
       render json: { errors: activity.errors.full_messages }, status: :bad_request
     end
   end
 
+  def destroy
+    pupil_resource = pupil_resources.find params[:id]
+    pupil_resource.purge
+    head :no_content
+  end
+
 private
+
+  def pupil_resources
+    @pupil_resources ||= activity.pupil_resources
+  end
+
+  def activity
+    @activity ||= Activity.with_attached_pupil_resources.find params[:activity_id]
+  end
 
   def pupil_resource_params
     params.require :pupil_resource

--- a/app/controllers/api/v1/pupil_resources_controller.rb
+++ b/app/controllers/api/v1/pupil_resources_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::PupilResourcesController < Api::BaseController
+  def create
+    activity = Activity.find_by! id: params[:activity_id]
+
+    if activity.pupil_resources.attach pupil_resource_params
+      head :created
+    else
+      render json: { errors: activity.errors.full_messages }, status: :bad_request
+    end
+  end
+
+private
+
+  def pupil_resource_params
+    params.require :pupil_resource
+  end
+end

--- a/app/controllers/api/v1/pupil_resources_controller.rb
+++ b/app/controllers/api/v1/pupil_resources_controller.rb
@@ -1,4 +1,16 @@
 class Api::V1::PupilResourcesController < Api::BaseController
+  def index
+    activity = Activity.find_by! id: params[:activity_id]
+
+    pupil_resources = activity.pupil_resources
+
+    render json: SimpleAMS::Renderer::Collection.new(
+      pupil_resources,
+      serializer: PupilResourceSerializer,
+      includes: []
+    ).to_json
+  end
+
   def create
     activity = Activity.find_by! id: params[:activity_id]
 

--- a/app/controllers/api/v1/teacher_resources_controller.rb
+++ b/app/controllers/api/v1/teacher_resources_controller.rb
@@ -1,4 +1,16 @@
 class Api::V1::TeacherResourcesController < Api::BaseController
+  def index
+    activity = Activity.find_by! id: params[:activity_id]
+
+    teacher_resources = activity.teacher_resources
+
+    render json: SimpleAMS::Renderer::Collection.new(
+      teacher_resources,
+      serializer: TeacherResourceSerializer,
+      includes: []
+    ).to_json
+  end
+
   def create
     activity = Activity.find_by! id: params[:activity_id]
 

--- a/app/controllers/api/v1/teacher_resources_controller.rb
+++ b/app/controllers/api/v1/teacher_resources_controller.rb
@@ -1,9 +1,5 @@
 class Api::V1::TeacherResourcesController < Api::BaseController
   def index
-    activity = Activity.find_by! id: params[:activity_id]
-
-    teacher_resources = activity.teacher_resources
-
     render json: SimpleAMS::Renderer::Collection.new(
       teacher_resources,
       serializer: TeacherResourceSerializer,
@@ -12,16 +8,28 @@ class Api::V1::TeacherResourcesController < Api::BaseController
   end
 
   def create
-    activity = Activity.find_by! id: params[:activity_id]
-
-    if activity.teacher_resources.attach teacher_resource_params
+    if teacher_resources.attach teacher_resource_params
       head :created
     else
       render json: { errors: activity.errors.full_messages }, status: :bad_request
     end
   end
 
+  def destroy
+    teacher_resource = teacher_resources.find params[:id]
+    teacher_resource.purge
+    head :no_content
+  end
+
 private
+
+  def teacher_resources
+    @teacher_resources ||= activity.teacher_resources
+  end
+
+  def activity
+    @activity ||= Activity.find params[:activity_id]
+  end
 
   def teacher_resource_params
     params.require :teacher_resource

--- a/app/controllers/api/v1/teacher_resources_controller.rb
+++ b/app/controllers/api/v1/teacher_resources_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::TeacherResourcesController < Api::BaseController
+  def create
+    activity = Activity.find_by! id: params[:activity_id]
+
+    if activity.teacher_resources.attach teacher_resource_params
+      head :created
+    else
+      render json: { errors: activity.errors.full_messages }, status: :bad_request
+    end
+  end
+
+private
+
+  def teacher_resource_params
+    params.require :teacher_resource
+  end
+end

--- a/app/serializers/pupil_resource_serializer.rb
+++ b/app/serializers/pupil_resource_serializer.rb
@@ -9,6 +9,7 @@ class PupilResourceSerializer
   belongs_to :activity, serializer: ActivitySerializer
 
   def url
+    # NOTE see note in TeacherResourceSerializer#url
     Rails.application.routes.url_helpers.url_for object
   end
 end

--- a/app/serializers/pupil_resource_serializer.rb
+++ b/app/serializers/pupil_resource_serializer.rb
@@ -1,0 +1,14 @@
+class PupilResourceSerializer
+  include SimpleAMS::DSL
+
+  adapter SimpleAMS::Adapters::AMS, root: false
+
+  fields :id
+  attributes :url
+
+  belongs_to :activity, serializer: ActivitySerializer
+
+  def url
+    Rails.application.routes.url_helpers.url_for object
+  end
+end

--- a/app/serializers/teacher_resource_serializer.rb
+++ b/app/serializers/teacher_resource_serializer.rb
@@ -9,6 +9,10 @@ class TeacherResourceSerializer
   belongs_to :activity, serializer: ActivitySerializer
 
   def url
+    # NOTE there is a bug in the SimpleAMS library which causes `object` to be
+    # cached when itterating through a collection.
+    # This causes our index endpoint for TeacherResources to return the same
+    # url for all TeacherResources.
     Rails.application.routes.url_helpers.url_for object
   end
 end

--- a/app/serializers/teacher_resource_serializer.rb
+++ b/app/serializers/teacher_resource_serializer.rb
@@ -1,0 +1,14 @@
+class TeacherResourceSerializer
+  include SimpleAMS::DSL
+
+  adapter SimpleAMS::Adapters::AMS, root: false
+
+  fields :id
+  attributes :url
+
+  belongs_to :activity, serializer: ActivitySerializer
+
+  def url
+    Rails.application.routes.url_helpers.url_for object
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,6 +60,9 @@ Rails.application.configure do
     Bullet.raise = true
     Bullet.rails_logger = true
   end
+
+
+  Rails.application.routes.default_url_options[:host] = ENV.fetch('HOST', 'localhost:3000')
 end
 
 OpenApi::Rswag::Api.configure do |c|

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,4 +104,5 @@ Rails.application.configure do
 
   # Custom app config
   config.x.swagger_root = ENV.fetch('SWAGGER_ROOT') { Rails.root.join('docs', 'swagger') }
+  Rails.application.routes.default_url_options[:host] = ENV.fetch('HOST')
 end

--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -101,4 +101,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  Rails.application.routes.default_url_options[:host] = "#{ENV.fetch('HEROKU_APP_NAME')}.herokuapp.com"
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -101,4 +101,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  Rails.application.routes.default_url_options[:host] = ENV.fetch('HOST')
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,4 +52,6 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.raise = true
   end
+
+  Rails.application.routes.default_url_options[:host] = ENV.fetch('HOST', 'example.com')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,8 +46,8 @@ Rails.application.routes.draw do
           resources :lessons, only: %i(index show create update) do
             resources :lesson_parts, only: %i(index show create update) do
               resources :activities, only: %i(index show create update) do
-                resources :pupil_resources, only: %i(index create)
-                resources :teacher_resources, only: %i(index create)
+                resources :pupil_resources, only: %i(index create destroy)
+                resources :teacher_resources, only: %i(index create destroy)
               end
             end
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,8 +46,8 @@ Rails.application.routes.draw do
           resources :lessons, only: %i(index show create update) do
             resources :lesson_parts, only: %i(index show create update) do
               resources :activities, only: %i(index show create update) do
-                resources :pupil_resources, only: %i(create)
-                resources :teacher_resources, only: %i(create)
+                resources :pupil_resources, only: %i(index create)
+                resources :teacher_resources, only: %i(index create)
               end
             end
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,10 @@ Rails.application.routes.draw do
         resources :units, only: %i(index show create update) do
           resources :lessons, only: %i(index show create update) do
             resources :lesson_parts, only: %i(index show create update) do
-              resources :activities, only: %i(index show create update)
+              resources :activities, only: %i(index show create update) do
+                resources :pupil_resources, only: %i(create)
+                resources :teacher_resources, only: %i(create)
+              end
             end
           end
         end

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -1335,6 +1335,69 @@
         }
       }
     },
+    "/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/pupil_resources/{pupil_resource_id}": {
+      "delete": {
+        "summary": "Removes the attached resource from the activity",
+        "tags": [
+          "PupilResource"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_part_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "activity_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pupil_resource_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pupil resource removed"
+          }
+        }
+      }
+    },
     "/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/teacher_resources": {
       "get": {
         "summary": "Returns the activity's attached teacher_resources",
@@ -1470,6 +1533,69 @@
           },
           "400": {
             "description": "invalid teacher_resource"
+          }
+        }
+      }
+    },
+    "/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/teacher_resources/{teacher_resource_id}": {
+      "delete": {
+        "summary": "Removes the attached resource from the activity",
+        "tags": [
+          "TeacherResource"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_part_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "activity_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teacher_resource_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "teacher resource removed"
           }
         }
       }

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -1197,6 +1197,67 @@
       }
     },
     "/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/pupil_resources": {
+      "get": {
+        "summary": "Returns the activity's attached pupil_resources",
+        "tags": [
+          "PupilResource"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_part_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "activity_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pupil resources found",
+            "examples": {
+              "application/json": [
+                {
+                  "id": 1,
+                  "url": "https://example.com/path-to-resource"
+                }
+              ]
+            }
+          }
+        }
+      },
       "post": {
         "summary": "Attaches a pupil resource to the activity",
         "tags": [
@@ -1275,6 +1336,67 @@
       }
     },
     "/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/teacher_resources": {
+      "get": {
+        "summary": "Returns the activity's attached teacher_resources",
+        "tags": [
+          "TeacherResource"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_part_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "activity_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "teacher resources found",
+            "examples": {
+              "application/json": [
+                {
+                  "id": 1,
+                  "url": "https://example.com/path-to-resource"
+                }
+              ]
+            }
+          }
+        }
+      },
       "post": {
         "summary": "Attaches a teacher resource to the activity",
         "tags": [

--- a/docs/swagger/v1/swagger.json
+++ b/docs/swagger/v1/swagger.json
@@ -104,6 +104,9 @@
           "id": {
             "type": "integer"
           },
+          "name": {
+            "type": "string"
+          },
           "overview": {
             "type": "string"
           },
@@ -168,21 +171,25 @@
             "examples": {
               "application/json": [
                 {
+                  "name": "Activity 1",
                   "overview": "Overview 1",
                   "duration": 20,
                   "extra_requirements": [
                     "PVA Glue",
                     "Glitter"
                   ],
+                  "default": false,
                   "id": 1
                 },
                 {
+                  "name": "Activity 2",
                   "overview": "Overview 2",
                   "duration": 20,
                   "extra_requirements": [
                     "PVA Glue",
                     "Glitter"
                   ],
+                  "default": false,
                   "id": 2
                 }
               ]
@@ -262,12 +269,14 @@
             "examples": {
               "application/json": {
                 "activity": {
+                  "name": "Activity 3",
                   "overview": "Overview 3",
                   "duration": 20,
                   "extra_requirements": [
                     "PVA Glue",
                     "Glitter"
-                  ]
+                  ],
+                  "default": true
                 }
               }
             }
@@ -331,12 +340,14 @@
             "description": "activity found",
             "examples": {
               "application/json": {
+                "name": "Activity 4",
                 "overview": "Overview 4",
                 "duration": 20,
                 "extra_requirements": [
                   "PVA Glue",
                   "Glitter"
                 ],
+                "default": false,
                 "id": 1
               }
             },
@@ -420,12 +431,14 @@
             "examples": {
               "application/json": {
                 "activity": {
+                  "name": "Activity 5",
                   "overview": "Overview 5",
                   "duration": 20,
                   "extra_requirements": [
                     "PVA Glue",
                     "Glitter"
-                  ]
+                  ],
+                  "default": false
                 }
               }
             }
@@ -1179,6 +1192,162 @@
           },
           "400": {
             "description": "invalid lesson"
+          }
+        }
+      }
+    },
+    "/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/pupil_resources": {
+      "post": {
+        "summary": "Attaches a pupil resource to the activity",
+        "tags": [
+          "PupilResource"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_part_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "activity_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pupil_resource": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "pupil_resource": {
+                  "contentType": "image/png"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "pupil_resouce created"
+          },
+          "400": {
+            "description": "invalid pupil_resource"
+          }
+        }
+      }
+    },
+    "/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/teacher_resources": {
+      "post": {
+        "summary": "Attaches a teacher resource to the activity",
+        "tags": [
+          "TeacherResource"
+        ],
+        "parameters": [
+          {
+            "name": "ccp_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "unit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lesson_part_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "activity_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "teacher_resource": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "teacher_resource": {
+                  "contentType": "image/png"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "teacher_resouce created"
+          },
+          "400": {
+            "description": "invalid teacher_resource"
           }
         }
       }

--- a/spec/fixtures/sample.xml
+++ b/spec/fixtures/sample.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<note>
+  <to>Testee</to>
+  <from>Tester</from>
+  <heading>Testing</heading>
+  <body>Test tests</body>
+</note>

--- a/spec/integration/api/v1/pupil_resources_controller_spec.rb
+++ b/spec/integration/api/v1/pupil_resources_controller_spec.rb
@@ -91,4 +91,40 @@ describe 'PupilResources' do
       end
     end
   end
+
+  path '/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/pupil_resources/{pupil_resource_id}' do
+    let :attachment_path do
+      File.join(Rails.application.root, 'spec', 'fixtures', '1px.png')
+    end
+
+    let :pupil_resource do
+      activity.pupil_resources.attach(
+        io: File.open(attachment_path),
+        filename: '1px.png',
+        content_type: 'image/png'
+      )
+      activity.pupil_resources.last
+    end
+
+    let :pupil_resource_id do
+      pupil_resource.id
+    end
+
+    delete %{Removes the attached resource from the activity} do
+      tags 'PupilResource'
+      parameter name: :ccp_id, in: :path, type: :string, required: true
+      parameter name: :unit_id, in: :path, type: :string, required: true
+      parameter name: :lesson_id, in: :path, type: :string, required: true
+      parameter name: :lesson_part_id, in: :path, type: :string, required: true
+      parameter name: :activity_id, in: :path, type: :string, required: true
+      parameter name: :pupil_resource_id, in: :path, type: :string, required: true
+
+      response '204', 'pupil resource removed' do
+        run_test! do |response|
+          expect(response.code).to eq '204'
+          expect(activity.reload.pupil_resources).to be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/integration/api/v1/pupil_resources_controller_spec.rb
+++ b/spec/integration/api/v1/pupil_resources_controller_spec.rb
@@ -1,0 +1,75 @@
+require 'swagger_helper'
+
+describe 'PupilResources' do
+  let(:activity) { create(:activity) }
+  let(:ccp_id) { activity.lesson_part.lesson.unit.complete_curriculum_programme.id }
+  let(:unit_id) { activity.lesson_part.lesson.unit.id }
+  let(:lesson_id) { activity.lesson_part.lesson.id }
+  let(:lesson_part_id) { activity.lesson_part.id }
+  let(:activity_id) { activity.id }
+
+  path '/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/pupil_resources' do
+    post 'Attaches a pupil resource to the activity' do
+      tags 'PupilResource'
+      consumes 'multipart/form-data'
+      produces 'application/json'
+      parameter name: :ccp_id, in: :path, type: :string, required: true
+      parameter name: :unit_id, in: :path, type: :string, required: true
+      parameter name: :lesson_id, in: :path, type: :string, required: true
+      parameter name: :lesson_part_id, in: :path, type: :string, required: true
+      parameter name: :activity_id, in: :path, type: :string, required: true
+      parameter name: :pupil_resource, in: :formData, type: :file, required: true
+
+      response 201, 'pupil_resouce created' do
+        let :attachment_path do
+          File.join(Rails.application.root, 'spec', 'fixtures', '1px.png')
+        end
+
+        let :pupil_resource do
+          fixture_file_upload attachment_path, 'image/png'
+        end
+
+        request_body \
+          content: {
+            'multipart/form-data': {
+              schema: {
+                type: 'object',
+                properties: {
+                  pupil_resource: {
+                    type: :string,
+                    format: :binary
+                  }
+                }
+              },
+              encoding: {
+                pupil_resource: {
+                  contentType: Activity::ALLOWED_CONTENT_TYPES.join(',')
+                }
+              }
+            }
+          }
+
+        run_test! do |response|
+          expect(response.code).to eq '201'
+        end
+      end
+
+      response 400, 'invalid pupil_resource' do
+        let :attachment_path do
+          File.join(Rails.application.root, 'spec', 'fixtures', 'sample.xml')
+        end
+
+        let :pupil_resource do
+          fixture_file_upload attachment_path, 'text/xml'
+        end
+
+        run_test! do |response|
+          expect(response.code).to eq '400'
+
+          expect(JSON.parse(response.body).dig('errors')).to include \
+            "Pupil resources has an invalid content type"
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/api/v1/pupil_resources_controller_spec.rb
+++ b/spec/integration/api/v1/pupil_resources_controller_spec.rb
@@ -9,6 +9,25 @@ describe 'PupilResources' do
   let(:activity_id) { activity.id }
 
   path '/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/pupil_resources' do
+    get %{Returns the activity's attached pupil_resources} do
+      tags 'PupilResource'
+      produces 'application/json'
+      parameter name: :ccp_id, in: :path, type: :string, required: true
+      parameter name: :unit_id, in: :path, type: :string, required: true
+      parameter name: :lesson_id, in: :path, type: :string, required: true
+      parameter name: :lesson_part_id, in: :path, type: :string, required: true
+      parameter name: :activity_id, in: :path, type: :string, required: true
+
+      response '200', 'pupil resources found' do
+        examples 'application/json': [{
+          id: 1,
+          url: 'https://example.com/path-to-resource'
+        }]
+
+        run_test!
+      end
+    end
+
     post 'Attaches a pupil resource to the activity' do
       tags 'PupilResource'
       consumes 'multipart/form-data'

--- a/spec/integration/api/v1/teacher_resources_controller_spec.rb
+++ b/spec/integration/api/v1/teacher_resources_controller_spec.rb
@@ -91,4 +91,40 @@ describe 'TeacherResources' do
       end
     end
   end
+
+  path '/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/teacher_resources/{teacher_resource_id}' do
+    let :attachment_path do
+      File.join(Rails.application.root, 'spec', 'fixtures', '1px.png')
+    end
+
+    let :teacher_resource do
+      activity.teacher_resources.attach(
+        io: File.open(attachment_path),
+        filename: '1px.png',
+        content_type: 'image/png'
+      )
+      activity.teacher_resources.last
+    end
+
+    let :teacher_resource_id do
+      teacher_resource.id
+    end
+
+    delete %{Removes the attached resource from the activity} do
+      tags 'TeacherResource'
+      parameter name: :ccp_id, in: :path, type: :string, required: true
+      parameter name: :unit_id, in: :path, type: :string, required: true
+      parameter name: :lesson_id, in: :path, type: :string, required: true
+      parameter name: :lesson_part_id, in: :path, type: :string, required: true
+      parameter name: :activity_id, in: :path, type: :string, required: true
+      parameter name: :teacher_resource_id, in: :path, type: :string, required: true
+
+      response '204', 'teacher resource removed' do
+        run_test! do |response|
+          expect(response.code).to eq '204'
+          expect(activity.reload.teacher_resources).to be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/integration/api/v1/teacher_resources_controller_spec.rb
+++ b/spec/integration/api/v1/teacher_resources_controller_spec.rb
@@ -9,6 +9,25 @@ describe 'TeacherResources' do
   let(:activity_id) { activity.id }
 
   path '/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/teacher_resources' do
+    get %{Returns the activity's attached teacher_resources} do
+      tags 'TeacherResource'
+      produces 'application/json'
+      parameter name: :ccp_id, in: :path, type: :string, required: true
+      parameter name: :unit_id, in: :path, type: :string, required: true
+      parameter name: :lesson_id, in: :path, type: :string, required: true
+      parameter name: :lesson_part_id, in: :path, type: :string, required: true
+      parameter name: :activity_id, in: :path, type: :string, required: true
+
+      response '200', 'teacher resources found' do
+        examples 'application/json': [{
+          id: 1,
+          url: 'https://example.com/path-to-resource'
+        }]
+
+        run_test!
+      end
+    end
+
     post 'Attaches a teacher resource to the activity' do
       tags 'TeacherResource'
       consumes 'multipart/form-data'

--- a/spec/integration/api/v1/teacher_resources_controller_spec.rb
+++ b/spec/integration/api/v1/teacher_resources_controller_spec.rb
@@ -1,0 +1,75 @@
+require 'swagger_helper'
+
+describe 'TeacherResources' do
+  let(:activity) { create(:activity) }
+  let(:ccp_id) { activity.lesson_part.lesson.unit.complete_curriculum_programme.id }
+  let(:unit_id) { activity.lesson_part.lesson.unit.id }
+  let(:lesson_id) { activity.lesson_part.lesson.id }
+  let(:lesson_part_id) { activity.lesson_part.id }
+  let(:activity_id) { activity.id }
+
+  path '/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/teacher_resources' do
+    post 'Attaches a teacher resource to the activity' do
+      tags 'TeacherResource'
+      consumes 'multipart/form-data'
+      produces 'application/json'
+      parameter name: :ccp_id, in: :path, type: :string, required: true
+      parameter name: :unit_id, in: :path, type: :string, required: true
+      parameter name: :lesson_id, in: :path, type: :string, required: true
+      parameter name: :lesson_part_id, in: :path, type: :string, required: true
+      parameter name: :activity_id, in: :path, type: :string, required: true
+      parameter name: :teacher_resource, in: :formData, type: :file, required: true
+
+      response 201, 'teacher_resouce created' do
+        let :attachment_path do
+          File.join(Rails.application.root, 'spec', 'fixtures', '1px.png')
+        end
+
+        let :teacher_resource do
+          fixture_file_upload attachment_path, 'image/png'
+        end
+
+        request_body \
+          content: {
+            'multipart/form-data': {
+              schema: {
+                type: 'object',
+                properties: {
+                  teacher_resource: {
+                    type: :string,
+                    format: :binary
+                  }
+                }
+              },
+              encoding: {
+                teacher_resource: {
+                  contentType: Activity::ALLOWED_CONTENT_TYPES.join(',')
+                }
+              }
+            }
+          }
+
+        run_test! do |response|
+          expect(response.code).to eq '201'
+        end
+      end
+
+      response 400, 'invalid teacher_resource' do
+        let :attachment_path do
+          File.join(Rails.application.root, 'spec', 'fixtures', 'sample.xml')
+        end
+
+        let :teacher_resource do
+          fixture_file_upload attachment_path, 'text/xml'
+        end
+
+        run_test! do |response|
+          expect(response.code).to eq '400'
+
+          expect(JSON.parse(response.body).dig('errors')).to include \
+            "Teacher resources has an invalid content type"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
We want to support attaching resources to an activity over the api

### Changes proposed in this pull request
Adds the ability to create, destroy, and index teacher and pupil resources over the api

### Guidance to review
Test out the swagger docs upload feature for pupil and teacher resources, note that currently the only supported content types are `image/png` (add to Activity::ALLOWED_CONTENT_TYPES if you want to support more).