### PR TITLE
Switching to blueprinter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "slim-rails"
 gem "redcarpet"
 gem "sentry-raven"
 gem "simple_ams"
+gem "blueprinter"
 gem "actionview-component"
 gem "aws-sdk-s3", require: false
 gem "govuk_design_system_formbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bindex (0.8.1)
+    blueprinter (0.23.0)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     brakeman (4.7.2)
@@ -334,6 +335,7 @@ DEPENDENCIES
   actionview-component
   active_storage_validations
   aws-sdk-s3
+  blueprinter
   bootsnap (>= 1.1.0)
   brakeman (= 4.7.2)
   bullet (~> 6.1)

--- a/app/controllers/api/v1/activities_controller.rb
+++ b/app/controllers/api/v1/activities_controller.rb
@@ -4,13 +4,7 @@ class Api::V1::ActivitiesController < Api::BaseController
       .where(lesson_part_id: params[:lesson_part_id])
       .all
 
-    render(
-      json: SimpleAMS::Renderer::Collection.new(
-        activities,
-        serializer: ActivitySerializer,
-        includes: []
-      ).to_json
-    )
+    render(json: serialize(activities))
   end
 
   def show
@@ -18,7 +12,7 @@ class Api::V1::ActivitiesController < Api::BaseController
       .where(lesson_part_id: params[:lesson_part_id])
       .find(params[:id])
 
-    render(json: serialize(activity).to_json)
+    render(json: serialize(activity))
   end
 
   def create
@@ -26,7 +20,7 @@ class Api::V1::ActivitiesController < Api::BaseController
     activity = lesson_part.activities.new(activity_params)
 
     if activity.save
-      render(json: serialize(activity).to_json, status: :created)
+      render(json: serialize(activity), status: :created)
     else
       render(json: { errors: activity.errors.full_messages }, status: :bad_request)
     end
@@ -36,7 +30,7 @@ class Api::V1::ActivitiesController < Api::BaseController
     activity = Activity.find_by!(lesson_part_id: params[:lesson_part_id], id: params[:id])
 
     if activity.update(activity_params)
-      render(json: serialize(activity).to_json, status: :ok)
+      render(json: serialize(activity), status: :ok)
     else
       render(json: { errors: activity.errors.full_messages }, status: :bad_request)
     end
@@ -48,10 +42,7 @@ private
     params.require(:activity).permit(:name, :overview, :duration, :default, extra_requirements: [])
   end
 
-  def serialize(lesson_part)
-    SimpleAMS::Renderer.new(
-      lesson_part,
-      serializer: ActivitySerializer
-    )
+  def serialize(data)
+    ActivitySerializer.render(data)
   end
 end

--- a/app/controllers/api/v1/complete_curriculum_programmes_controller.rb
+++ b/app/controllers/api/v1/complete_curriculum_programmes_controller.rb
@@ -2,13 +2,7 @@ class Api::V1::CompleteCurriculumProgrammesController < Api::BaseController
   def index
     ccps = CompleteCurriculumProgramme.all
 
-    render(
-      json: SimpleAMS::Renderer::Collection.new(
-        ccps,
-        serializer: CompleteCurriculumProgrammeSerializer,
-        includes: []
-      ).to_json
-    )
+    render(json: serialize(ccps))
   end
 
   def show
@@ -16,14 +10,14 @@ class Api::V1::CompleteCurriculumProgrammesController < Api::BaseController
       .eager_load(:units)
       .find(params[:id])
 
-    render(json: serialize(ccp).to_json)
+    render(json: serialize(ccp))
   end
 
   def create
     ccp = CompleteCurriculumProgramme.new(ccp_params)
 
     if ccp.save
-      render(json: serialize(ccp).to_json, status: :created)
+      render(json: serialize(ccp), status: :created)
     else
       render(json: { errors: ccp.errors.full_messages }, status: :bad_request)
     end
@@ -33,7 +27,7 @@ class Api::V1::CompleteCurriculumProgrammesController < Api::BaseController
     ccp = CompleteCurriculumProgramme.find(params[:id])
 
     if ccp.update(ccp_params)
-      render(json: serialize(ccp).to_json, status: :ok)
+      render(json: serialize(ccp), status: :ok)
     else
       render(json: { errors: ccp.errors.full_messages }, status: :bad_request)
     end
@@ -45,10 +39,7 @@ private
     params.require(:ccp).permit(:name, :overview, :benefits)
   end
 
-  def serialize(ccp)
-    SimpleAMS::Renderer.new(
-      ccp,
-      serializer: CompleteCurriculumProgrammeSerializer
-    )
+  def serialize(data)
+    CompleteCurriculumProgrammeSerializer.render(data)
   end
 end

--- a/app/controllers/api/v1/lesson_parts_controller.rb
+++ b/app/controllers/api/v1/lesson_parts_controller.rb
@@ -1,16 +1,10 @@
 class Api::V1::LessonPartsController < Api::BaseController
   def index
-    lessons_parts = LessonPart
+    lesson_parts = LessonPart
       .where(lesson_id: params[:lesson_id])
       .all
 
-    render(
-      json: SimpleAMS::Renderer::Collection.new(
-        lessons_parts,
-        serializer: LessonPartSerializer,
-        includes: []
-      ).to_json
-    )
+    render(json: serialize(lesson_parts))
   end
 
   def show
@@ -19,7 +13,7 @@ class Api::V1::LessonPartsController < Api::BaseController
       .where(lesson_id: params[:lesson_id])
       .find(params[:id])
 
-    render(json: serialize(lesson_part).to_json)
+    render(json: serialize(lesson_part))
   end
 
   def create
@@ -27,7 +21,7 @@ class Api::V1::LessonPartsController < Api::BaseController
     lesson_part = lesson.lesson_parts.new(lesson_part_params)
 
     if lesson_part.save
-      render(json: serialize(lesson_part).to_json, status: :created)
+      render(json: serialize(lesson_part), status: :created)
     else
       render(json: { errors: lesson_part.errors.full_messages }, status: :bad_request)
     end
@@ -37,7 +31,7 @@ class Api::V1::LessonPartsController < Api::BaseController
     lesson_part = LessonPart.find_by!(lesson_id: params[:lesson_id], id: params[:id])
 
     if lesson_part.update(lesson_part_params)
-      render(json: serialize(lesson_part).to_json, status: :ok)
+      render(json: serialize(lesson_part), status: :ok)
     else
       render(json: { errors: lesson_part.errors.full_messages }, status: :bad_request)
     end
@@ -49,10 +43,7 @@ private
     params.require(:lesson_part).permit(:position)
   end
 
-  def serialize(lesson_part)
-    SimpleAMS::Renderer.new(
-      lesson_part,
-      serializer: LessonPartSerializer
-    )
+  def serialize(data)
+    LessonPartSerializer.render(data)
   end
 end

--- a/app/controllers/api/v1/lessons_controller.rb
+++ b/app/controllers/api/v1/lessons_controller.rb
@@ -5,13 +5,7 @@ class Api::V1::LessonsController < Api::BaseController
       .where(unit_id: params[:unit_id])
       .all
 
-    render(
-      json: SimpleAMS::Renderer::Collection.new(
-        lessons,
-        serializer: LessonSerializer,
-        includes: []
-      ).to_json
-    )
+    render(json: serialize(lessons))
   end
 
   def show
@@ -20,7 +14,7 @@ class Api::V1::LessonsController < Api::BaseController
       .where(unit_id: params[:unit_id])
       .find(params[:id])
 
-    render(json: serialize(lesson).to_json)
+    render(json: serialize(lesson))
   end
 
   def create
@@ -28,7 +22,7 @@ class Api::V1::LessonsController < Api::BaseController
     lesson = unit.lessons.new(lesson_params)
 
     if lesson.save
-      render(json: serialize(lesson).to_json, status: :created)
+      render(json: serialize(lesson), status: :created)
     else
       render(json: { errors: lesson.errors.full_messages }, status: :bad_request)
     end
@@ -38,7 +32,7 @@ class Api::V1::LessonsController < Api::BaseController
     lesson = Lesson.find_by!(unit_id: params[:unit_id], id: params[:id])
 
     if lesson.update(lesson_params)
-      render(json: serialize(lesson).to_json, status: :ok)
+      render(json: serialize(lesson), status: :ok)
     else
       render(json: { errors: lesson.errors.full_messages }, status: :bad_request)
     end
@@ -58,10 +52,7 @@ private
     )
   end
 
-  def serialize(lesson)
-    SimpleAMS::Renderer.new(
-      lesson,
-      serializer: LessonSerializer
-    )
+  def serialize(data)
+    LessonSerializer.render(data)
   end
 end

--- a/app/controllers/api/v1/pupil_resources_controller.rb
+++ b/app/controllers/api/v1/pupil_resources_controller.rb
@@ -1,10 +1,6 @@
 class Api::V1::PupilResourcesController < Api::BaseController
   def index
-    render json: SimpleAMS::Renderer::Collection.new(
-      pupil_resources,
-      serializer: PupilResourceSerializer,
-      includes: []
-    ).to_json
+    render json: PupilResourceSerializer.render(pupil_resources.blobs)
   end
 
   def create

--- a/app/controllers/api/v1/teacher_resources_controller.rb
+++ b/app/controllers/api/v1/teacher_resources_controller.rb
@@ -1,10 +1,6 @@
 class Api::V1::TeacherResourcesController < Api::BaseController
   def index
-    render json: SimpleAMS::Renderer::Collection.new(
-      teacher_resources,
-      serializer: TeacherResourceSerializer,
-      includes: []
-    ).to_json
+    render json: TeacherResourceSerializer.render(teacher_resources.blobs)
   end
 
   def create

--- a/app/controllers/api/v1/units_controller.rb
+++ b/app/controllers/api/v1/units_controller.rb
@@ -2,15 +2,8 @@ class Api::V1::UnitsController < Api::BaseController
   def index
     units = Unit
       .where(complete_curriculum_programme_id: params[:ccp_id])
-      .all
 
-    render(
-      json: SimpleAMS::Renderer::Collection.new(
-        units,
-        serializer: UnitSerializer,
-        includes: []
-      ).to_json
-    )
+    render(json: serialize(units))
   end
 
   def show
@@ -18,7 +11,7 @@ class Api::V1::UnitsController < Api::BaseController
       .where(complete_curriculum_programme_id: params[:ccp_id])
       .find(params[:id])
 
-    render(json: serialize(unit).to_json)
+    render(json: serialize(unit))
   end
 
   def create
@@ -26,7 +19,7 @@ class Api::V1::UnitsController < Api::BaseController
     unit = ccp.units.new(unit_params)
 
     if unit.save
-      render(json: serialize(unit).to_json, status: :created)
+      render(json: serialize(unit), status: :created)
     else
       render(json: { errors: unit.errors.full_messages }, status: :bad_request)
     end
@@ -36,7 +29,7 @@ class Api::V1::UnitsController < Api::BaseController
     unit = Unit.find_by!(id: params[:id], complete_curriculum_programme_id: params[:ccp_id])
 
     if unit.update(unit_params)
-      render(json: serialize(unit).to_json, status: :ok)
+      render(json: serialize(unit), status: :ok)
     else
       render(json: { errors: unit.errors.full_messages }, status: :bad_request)
     end
@@ -48,10 +41,7 @@ private
     params.require(:unit).permit(:name, :overview, :benefits, :position)
   end
 
-  def serialize(unit)
-    SimpleAMS::Renderer.new(
-      unit,
-      serializer: UnitSerializer
-    )
+  def serialize(data)
+    UnitSerializer.render(data)
   end
 end

--- a/app/serializers/activity_serializer.rb
+++ b/app/serializers/activity_serializer.rb
@@ -1,9 +1,5 @@
-class ActivitySerializer
-  include SimpleAMS::DSL
+class ActivitySerializer < Blueprinter::Base
+  identifier :id
 
-  adapter SimpleAMS::Adapters::AMS, root: false
-
-  fields :id, :name, :overview, :duration, :default, :extra_requirements
-
-  belongs_to :lesson_part, serializer: LessonPartSerializer
+  fields :name, :overview, :duration, :default, :extra_requirements
 end

--- a/app/serializers/complete_curriculum_programme_serializer.rb
+++ b/app/serializers/complete_curriculum_programme_serializer.rb
@@ -1,10 +1,5 @@
-class CompleteCurriculumProgrammeSerializer
-  include SimpleAMS::DSL
+class CompleteCurriculumProgrammeSerializer < Blueprinter::Base
+  identifier :id
 
-  adapter SimpleAMS::Adapters::AMS, root: false
-
-  fields :id, :name, :overview, :benefits
-  generic :include_embedded_data, false
-
-  has_many :units, serializer: UnitSerializer
+  fields :name, :overview, :benefits
 end

--- a/app/serializers/lesson_part_serializer.rb
+++ b/app/serializers/lesson_part_serializer.rb
@@ -1,9 +1,5 @@
-class LessonPartSerializer
-  include SimpleAMS::DSL
+class LessonPartSerializer < Blueprinter::Base
+  identifier :id
 
-  adapter SimpleAMS::Adapters::AMS, root: false
-
-  fields :id, :position
-
-  belongs_to :lesson, serializer: LessonSerializer
+  fields :position
 end

--- a/app/serializers/lesson_serializer.rb
+++ b/app/serializers/lesson_serializer.rb
@@ -1,11 +1,6 @@
-class LessonSerializer
-  include SimpleAMS::DSL
+class LessonSerializer < Blueprinter::Base
+  identifier :id
 
-  adapter SimpleAMS::Adapters::AMS, root: false
-
-  fields :id, :name, :summary, :position, :core_knowledge,
+  fields :name, :summary, :position, :core_knowledge,
          :previous_knowledge, :vocabulary, :misconceptions
-
-  belongs_to :unit, serializer: UnitSerializer
-  has_many :lesson_parts, serializer: LessonPartSerializer
 end

--- a/app/serializers/pupil_resource_serializer.rb
+++ b/app/serializers/pupil_resource_serializer.rb
@@ -1,15 +1,7 @@
-class PupilResourceSerializer
-  include SimpleAMS::DSL
+class PupilResourceSerializer < Blueprinter::Base
+  identifier :id
 
-  adapter SimpleAMS::Adapters::AMS, root: false
-
-  fields :id
-  attributes :url
-
-  belongs_to :activity, serializer: ActivitySerializer
-
-  def url
-    # NOTE see note in TeacherResourceSerializer#url
+  field :url do |object|
     Rails.application.routes.url_helpers.url_for object
   end
 end

--- a/app/serializers/teacher_resource_serializer.rb
+++ b/app/serializers/teacher_resource_serializer.rb
@@ -1,18 +1,7 @@
-class TeacherResourceSerializer
-  include SimpleAMS::DSL
+class TeacherResourceSerializer < Blueprinter::Base
+  identifier :id
 
-  adapter SimpleAMS::Adapters::AMS, root: false
-
-  fields :id
-  attributes :url
-
-  belongs_to :activity, serializer: ActivitySerializer
-
-  def url
-    # NOTE there is a bug in the SimpleAMS library which causes `object` to be
-    # cached when itterating through a collection.
-    # This causes our index endpoint for TeacherResources to return the same
-    # url for all TeacherResources.
+  field :url do |object|
     Rails.application.routes.url_helpers.url_for object
   end
 end

--- a/app/serializers/unit_serializer.rb
+++ b/app/serializers/unit_serializer.rb
@@ -1,13 +1,5 @@
-class UnitSerializer
-  include SimpleAMS::DSL
+class UnitSerializer < Blueprinter::Base
+  identifier :id
 
-  type :unit
-  collection :units
-
-  adapter SimpleAMS::Adapters::AMS, root: false
-
-  fields :id, :name, :overview, :benefits, :position
-
-  belongs_to :complete_curriculum_programme, serializer: CompleteCurriculumProgrammeSerializer
-  has_many :lessons, serializer: LessonSerializer
+  fields :name, :overview, :benefits, :position
 end


### PR DESCRIPTION
### Context

[SimpleAMS](https://www.github.com/vasilakisfil/SimpleAMS) suffered from a bug that caused objects to be cached incorrectly.

### Changes proposed in this pull request

Switch out serialisation to [Blueprinter](https://github.com/procore/blueprinter). Note that I have left out associations on purpose, we don't _need_ them yet. Blueprinter supports the behaviour fully so they should be straightforward to add when required.

The code in the API controllers also looks cleaner now :sparkles: 

### Guidance to review

Ensure the change looks sensible and everything works.
