### PR TITLE
Disable bullet for activestorage querys

### DIFF
--- a/app/controllers/api/v1/teacher_resources_controller.rb
+++ b/app/controllers/api/v1/teacher_resources_controller.rb
@@ -28,7 +28,7 @@ private
   end
 
   def activity
-    @activity ||= Activity.find params[:activity_id]
+    @activity ||= Activity.with_attached_teacher_resources.find params[:activity_id]
   end
 
   def teacher_resource_params

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,6 +59,8 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.raise = true
     Bullet.rails_logger = true
+    # FIXME: Remove once https://github.com/flyerhzm/bullet/issues/474 is resolved
+    Bullet.add_whitelist type: :n_plus_one_query, class_name: "ActiveStorage::Attachment", association: :blob
   end
 
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,6 +51,8 @@ Rails.application.configure do
   config.after_initialize do
     Bullet.enable = true
     Bullet.raise = true
+    # FIXME: Remove once https://github.com/flyerhzm/bullet/issues/474 is resolved
+    Bullet.add_whitelist type: :n_plus_one_query, class_name: "ActiveStorage::Attachment", association: :blob
   end
 
   Rails.application.routes.default_url_options[:host] = ENV.fetch('HOST', 'example.com')


### PR DESCRIPTION
There seems to be an issue with activestorage causing n + 1 querys when
attaching a file. We're already using the provided eagerloading scope
that active storage generates, the issue looks like it's caused by the
way the attach method works.
See this issue on the bullet repo for more details
`https://github.com/flyerhzm/bullet/issues/474`

### Context

### Changes proposed in this pull request

### Guidance to review

