### PR TITLE
Cmb 534/update ccp model to match prototype attributes

### DIFF
--- a/app/controllers/api/v1/complete_curriculum_programmes_controller.rb
+++ b/app/controllers/api/v1/complete_curriculum_programmes_controller.rb
@@ -36,7 +36,7 @@ class Api::V1::CompleteCurriculumProgrammesController < Api::BaseController
 private
 
   def ccp_params
-    params.require(:ccp).permit(:name, :overview, :benefits)
+    params.require(:ccp).permit(:name, :rationale)
   end
 
   def serialize(data)

--- a/app/models/complete_curriculum_programme.rb
+++ b/app/models/complete_curriculum_programme.rb
@@ -1,11 +1,6 @@
 class CompleteCurriculumProgramme < ApplicationRecord
-  validates :name,
-            presence: true,
-            length: { maximum: 256 }
-  validates :overview,
-            presence: true,
-            length: { maximum: 1024 }
-  validates :benefits, presence: true
+  validates :name, presence: true, length: { maximum: 256 }
+  validates :rationale, presence: true
 
   has_many :units, dependent: :destroy
 

--- a/app/serializers/complete_curriculum_programme_serializer.rb
+++ b/app/serializers/complete_curriculum_programme_serializer.rb
@@ -1,5 +1,5 @@
 class CompleteCurriculumProgrammeSerializer < Blueprinter::Base
   identifier :id
 
-  fields :name, :overview, :benefits
+  fields :name, :rationale
 end

--- a/app/views/teachers/complete_curriculum_programmes/show.slim
+++ b/app/views/teachers/complete_curriculum_programmes/show.slim
@@ -4,12 +4,8 @@ h1 = @complete_curriculum_programme.name
 
 section
   h2.govuk-heading-m What is covered in #{@complete_curriculum_programme.year}
-  = markdown @complete_curriculum_programme.overview
+  = markdown @complete_curriculum_programme.rationale
 
 section.cards-container
   - @complete_curriculum_programme.units.each do |unit|
     = render "unit_card", unit: unit
-
-section class="govuk-!-margin-top-4"
-  h2.govuk-heading-m How the #{@complete_curriculum_programme.name} benefits pupils’ learning
-  = markdown @complete_curriculum_programme.benefits

--- a/app/views/teachers/complete_curriculum_programmes/show.slim
+++ b/app/views/teachers/complete_curriculum_programmes/show.slim
@@ -2,8 +2,7 @@
 
 h1 = @complete_curriculum_programme.name
 
-section
-  h2.govuk-heading-m What is covered in #{@complete_curriculum_programme.year}
+section.rationale
   = markdown @complete_curriculum_programme.rationale
 
 section.cards-container

--- a/db/migrate/20200123094857_create_complete_curriculum_programmes.rb
+++ b/db/migrate/20200123094857_create_complete_curriculum_programmes.rb
@@ -2,8 +2,7 @@ class CreateCompleteCurriculumProgrammes < ActiveRecord::Migration[6.0]
   def change
     create_table :complete_curriculum_programmes do |t|
       t.string :name, null: false, limit: 256
-      t.string :overview, null: false, limit: 1024
-      t.text :benefits, null: false
+      t.text :rationale, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,8 +72,7 @@ ActiveRecord::Schema.define(version: 2020_02_26_092814) do
 
   create_table "complete_curriculum_programmes", force: :cascade do |t|
     t.string "name", limit: 256, null: false
-    t.string "overview", limit: 1024, null: false
-    t.text "benefits", null: false
+    t.text "rationale", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_complete_curriculum_programmes_on_name"

--- a/db/seeds/data/history/the-norman-invasion.yml
+++ b/db/seeds/data/history/the-norman-invasion.yml
@@ -1,13 +1,6 @@
 ccp:
   name: Year 7 History - The Norman Invasion
-  overview: |-
-    The Battle of Hastings was fought on 14 October 1066 between the
-    Norman-French army of William, the Duke of Normandy, and an English army
-    under the Anglo-Saxon King Harold Godwinson, beginning the Norman conquest of
-    England. It took place approximately 7 miles northwest of Hastings, close to
-    the present-day town of Battle, East Sussex, and was a decisive Norman
-    victory.
-  benefits: |-
+  rationale: |-
     The lessons in this unit have been planned progressively to enable pupils to
     retain powerful knowledge and vocabulary that can be used confidently later
     in life. Progressively planned learning enables children to apply prior

--- a/db/seeds/seeders/ccp_seeder.rb
+++ b/db/seeds/seeders/ccp_seeder.rb
@@ -2,10 +2,9 @@ module Seeders
   class CCPSeeder < BaseSeeder
     attr_accessor :id, :name, :overview, :benefits
 
-    def initialize(name:, overview:, benefits:)
-      @name     = name
-      @overview = overview
-      @benefits = benefits
+    def initialize(name:, rationale:)
+      @name      = name
+      @rationale = rationale
     end
 
     def identifier
@@ -27,7 +26,7 @@ module Seeders
     end
 
     def attributes
-      { name: @name, overview: @overview, benefits: @benefits }
+      { name: @name, rationale: @rationale }
     end
 
     def payload

--- a/spec/factories/complete_curriculum_programme.rb
+++ b/spec/factories/complete_curriculum_programme.rb
@@ -1,13 +1,11 @@
 FactoryBot.define do
   factory(:complete_curriculum_programme, aliases: %i(ccp)) do
     sequence(:name) { |n| "CCP #{n}" }
-    overview { "Overview" }
-    benefits { "Benefits" }
+    rationale { "Rationale" }
 
     trait(:randomised) do
       name { Faker::University.name }
-      overview { Faker::Lorem.paragraph }
-      benefits { Faker::Lorem.paragraphs.join("\n\n") }
+      rationale { Faker::Lorem.paragraphs.join("\n\n") }
     end
 
     trait(:with_units) do

--- a/spec/models/complete_curriculum_programme_spec.rb
+++ b/spec/models/complete_curriculum_programme_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe CompleteCurriculumProgramme, type: :model do
   describe 'columns' do
     it { is_expected.to have_db_column(:name).of_type(:string) }
-    it { is_expected.to have_db_column(:overview).of_type(:string) }
-    it { is_expected.to have_db_column(:benefits).of_type(:text) }
   end
 
   describe 'validation' do
@@ -13,12 +11,7 @@ RSpec.describe CompleteCurriculumProgramme, type: :model do
       it { is_expected.to validate_length_of(:name).is_at_most(256) }
     end
 
-    describe 'overview' do
-      it { is_expected.to validate_presence_of(:overview) }
-      it { is_expected.to validate_length_of(:overview).is_at_most(1024) }
-    end
-
-    it { is_expected.to validate_presence_of(:benefits) }
+    it { is_expected.to validate_presence_of(:rationale) }
   end
 
   describe 'relationships' do

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -26,10 +26,9 @@ RSpec.configure do |config|
             properties: {
               id: { type: :integer },
               name: { type: :string },
-              benefits: { type: :string },
-              overview: { type: :string },
+              ratoinale: { type: :string }
             },
-            required: %i(name benefits overview)
+            required: %i(name rationale)
           },
           unit: {
             type: :object,


### PR DESCRIPTION
### Context

The prototype has moved on and replaced `CCP#overview` and `#benefits` with a block of text that's more of a rationale.

### Changes proposed in this pull request

Replace `#benefits` and `#overview` with `#rationale`, update the templates and seeds accordingly

### Guidance to review

Do the changes make sense? Are we actually doing the right thing here @Bethlt4?
