### PR TITLE
Change the metadata column to jsonb

### DIFF
--- a/db/migrate/20200214203034_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200214203034_create_active_storage_tables.active_storage.rb
@@ -6,7 +6,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.string   :key,        null: false
       t.string   :filename,   null: false
       t.string   :content_type
-      t.text     :metadata
+      t.jsonb    :metadata
       t.bigint   :byte_size,  null: false
       t.string   :checksum,   null: false
       t.datetime :created_at, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2020_02_26_092814) do
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
-    t.text "metadata"
+    t.jsonb "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
PostgreSQL supports JSON natively[0], the jsonb format provides a binary
representation of the parsed JSON that allows queries to be made
directly on the column's contents[1], allows the contents to be fully
indexed[2] and manipulated[3] and is generally more efficient than
storing as plain text.

[0] https://www.postgresql.org/docs/12/datatype-json.html
[1] https://www.postgresql.org/docs/12/datatype-json.html#JSON-KEYS-ELEMENTS
[2] https://www.postgresql.org/docs/12/datatype-json.html#JSON-INDEXING
[3] https://www.postgresql.org/docs/12/functions-json.html