### PR TITLE
Fix ordering and use a counter to mark lesson parts

### DIFF
--- a/app/controllers/teachers/lessons_controller.rb
+++ b/app/controllers/teachers/lessons_controller.rb
@@ -13,7 +13,10 @@ module Teachers
   private
 
     def load_resources
-      @lesson = Lesson.includes(:lesson_parts).find(params[:id])
+      @lesson = Lesson
+        .eager_load(lesson_parts: { activities: [:activity_choices, :teaching_methods, { activity_teaching_methods: :teaching_method }] })
+        .merge(LessonPart.ordered_by_position)
+        .find(params[:id])
 
       @presenter = Teachers::LessonContentsPresenter.new(@lesson, current_teacher)
     end

--- a/app/controllers/teachers/units_controller.rb
+++ b/app/controllers/teachers/units_controller.rb
@@ -3,6 +3,7 @@ module Teachers
     def show
       @unit = Unit
         .eager_load(:lessons, complete_curriculum_programme: :units)
+        .merge(Lesson.ordered_by_position)
         .find(params[:id])
     end
   end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -8,8 +8,9 @@ class Lesson < ApplicationRecord
   validates :summary, presence: true
 
   belongs_to :unit
-
   has_many :lesson_parts, dependent: :destroy
+
+  scope :ordered_by_position, -> { order(position: 'asc') }
 
   def duration
     '1 hour'

--- a/app/models/lesson_part.rb
+++ b/app/models/lesson_part.rb
@@ -9,8 +9,10 @@ class LessonPart < ApplicationRecord
 
   validates :position, uniqueness: { scope: :lesson_id }
 
+  scope :ordered_by_position, -> { order(position: 'asc') }
+
   def activity_for(teacher)
-    activity_choice = ActivityChoice.find_by(teacher_id: teacher.id, lesson_part_id: id)
+    activity_choice = activity_choices.find_by(teacher_id: teacher.id)
 
     return activity_choice.activity if activity_choice.present?
 

--- a/app/presenters/teachers/lesson_contents_presenter.rb
+++ b/app/presenters/teachers/lesson_contents_presenter.rb
@@ -1,11 +1,11 @@
 module Teachers
   class LessonContentsPresenter
     class Slot
-      attr_reader :position, :teaching_methods, :name, :overview, :duration,
+      attr_reader :counter, :teaching_methods, :name, :overview, :duration,
                   :extra_requirements, :lesson_part_id, :alternatives
 
-      def initialize(lesson_part, activity)
-        @position           = lesson_part.position
+      def initialize(counter, lesson_part, activity)
+        @counter            = counter
         @teaching_methods   = activity.teaching_methods
         @name               = activity.name
         @overview           = activity.overview
@@ -23,7 +23,8 @@ module Teachers
         .lesson_parts
         .each_with_object({}) { |lesson_part, hash| hash[lesson_part] = lesson_part.activity_for(teacher) }
         .reject { |_, activity| activity.nil? }
-        .map { |lesson_part, activity| Slot.new(lesson_part, activity) }
+        .map
+        .with_index(1) { |(lesson_part, activity), i| Slot.new(i, lesson_part, activity) }
     end
   end
 end

--- a/app/views/teachers/lessons/_lesson_contents.slim
+++ b/app/views/teachers/lessons/_lesson_contents.slim
@@ -35,7 +35,7 @@ section.lesson-plan
           tr.govuk-table__row
             th.govuk-table__cell.big-number
               span.govuk-visually-hidden Lesson part number
-              = slot.position
+              = slot.counter
 
             td.govuk-table__cell.activity-icons
               ul.govuk-list

--- a/spec/models/lesson_part_spec.rb
+++ b/spec/models/lesson_part_spec.rb
@@ -70,4 +70,17 @@ describe LessonPart, type: :model do
       end
     end
   end
+
+  describe 'scopes' do
+    describe '.ordered_by_position' do
+      let!(:second) { create(:lesson_part, position: 3) }
+      let!(:third) { create(:lesson_part, position: 1) }
+      let!(:first) { create(:lesson_part, position: 5) }
+
+      specify 'should return the lesson parts in ascending order of position' do
+        expect(LessonPart.all).to contain_exactly(second, third, first)
+        expect(LessonPart.all.ordered_by_position).to contain_exactly(first, second, third)
+      end
+    end
+  end
 end

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -29,4 +29,17 @@ RSpec.describe Unit, type: :model do
     it { is_expected.to belong_to(:complete_curriculum_programme) }
     it { is_expected.to have_many(:lessons).dependent(:destroy) }
   end
+
+  describe 'scopes' do
+    describe '.ordered_by_position' do
+      let!(:second) { create(:lesson, position: 3) }
+      let!(:third) { create(:lesson, position: 1) }
+      let!(:first) { create(:lesson, position: 5) }
+
+      specify 'should return the lessons in ascending order of position' do
+        expect(Lesson.all).to contain_exactly(second, third, first)
+        expect(Lesson.all.ordered_by_position).to contain_exactly(first, second, third)
+      end
+    end
+  end
 end

--- a/spec/presenters/teachers/lesson_contents_presenter_spec.rb
+++ b/spec/presenters/teachers/lesson_contents_presenter_spec.rb
@@ -19,9 +19,11 @@ RSpec.describe Teachers::LessonContentsPresenter do
   end
 
   specify 'each slot should have the correct attributes' do
-    lesson.lesson_parts.each do |lesson_part|
+    lesson.lesson_parts.each.with_index(1) do |lesson_part, i|
       subject.contents.find { |slot| slot.lesson_part_id == lesson_part.id }.tap do |slot|
         activity = lesson_part.activity_for(teacher)
+
+        expect(slot.counter).to eql(i)
 
         expect(slot.duration).to eql(activity.duration)
         expect(slot.overview).to eql(activity.overview)
@@ -29,7 +31,6 @@ RSpec.describe Teachers::LessonContentsPresenter do
         expect(slot.alternatives).to eql(activity.alternatives)
         expect(slot.teaching_methods).to match_array(activity.teaching_methods)
 
-        expect(slot.position).to eql(lesson_part.position)
         expect(slot.lesson_part_id).to eql(lesson_part.id)
       end
     end

--- a/spec/views/teachers/lessons/_lesson_contents.slim_spec.rb
+++ b/spec/views/teachers/lessons/_lesson_contents.slim_spec.rb
@@ -14,8 +14,10 @@ RSpec.describe "teachers/lessons/_lesson_contents" do
   it "includes the lesson parts" do
     render
     expect(rendered).to have_css('table.lesson-parts.govuk-table')
-    presenter.contents.each do |slot|
-      expect(rendered).to have_css('th.govuk-table__cell.big-number', text: slot.position)
+    presenter.contents.each.with_index(1) do |slot, i|
+      expect(rendered).to have_css('th.govuk-table__cell.big-number', text: i)
+      expect(rendered).to have_content(slot.name)
+      expect(rendered).to have_content(slot.overview)
     end
   end
 


### PR DESCRIPTION
Lesson parts were displayed with their position as the sequence number. This might work now but at some point this will probably be changed for acts_as_list or similar, so use `#with_index` to iterate so they are always numbered 1..X.

This change also adds a scope that forces the order by `#position`.
