### PR TITLE
Mark downloads as failed on error

### DIFF
--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -11,5 +11,9 @@ class DownloadJob < ApplicationJob
     )
 
     download.transition_to!(:completed)
+  rescue StandardError => e
+    download.transition_to! :failed
+    Raven.capture_exception e
+    raise error
   end
 end


### PR DESCRIPTION
### Context
If we run into an error when building and attaching the lesson zip to the download we want to mark the download as failed so we can reflect that to the teacher.

### Changes proposed in this pull request
Adds a rescue block to the job, updates downloads state to failed on error.
Adds a temporary stub class just to raise errors  for testing.

### Guidance to review
Should look sensible.

