### PR TITLE
Make lesson contents responsive

### DIFF
--- a/app/helpers/teachers/lessons_helper.rb
+++ b/app/helpers/teachers/lessons_helper.rb
@@ -12,8 +12,8 @@ module Teachers
     def activity_icon(teaching_method)
       image_tag(
         asset_pack_path("media/images/activity-icons/#{teaching_method.icon}.png"),
-        width: '75px',
-        alt: "#{teaching_method.name} icon"
+        alt: "#{teaching_method.name} icon",
+        class: "activity-icon"
       )
     end
 

--- a/app/views/layouts/print.slim
+++ b/app/views/layouts/print.slim
@@ -12,4 +12,3 @@ html lang="en" class="govuk-template "
     .govuk-width-container
       main#main-content.govuk-main-wrapper[role="main"]
         = yield
-    = render 'layouts/shared/footer'

--- a/app/views/teachers/lessons/_lesson_contents.slim
+++ b/app/views/teachers/lessons/_lesson_contents.slim
@@ -1,4 +1,4 @@
-section.lesson-plan
+section
   - if @lesson.lesson_parts.none?
 
     .govuk-warning-text
@@ -16,56 +16,43 @@ section.lesson-plan
       | This lesson has been sequenced in a suggested order. If you'd like to make
         changes, you can search for alternative resources.
 
-    table.lesson-parts.govuk-table
-      thead.govuk-table__head
-        tr.govuk-table__row
-          th
-            span.govuk-visually-hidden
-              Lesson part count
-          th.govuk-table__header.activity-icons scope='col'
-            | Learning method
-          th.govuk-table__header scope='col'
-            | Teaching this activity
+
+    div.lesson-parts
+      - @presenter.contents.each do |slot|
+
+        div.lesson-part
+          div.counter.big-number
+            = slot.counter
+
+          div.teaching-methods
+            - slot.teaching_methods.each do |tm|
+
+              div.teaching-method
+                = activity_icon(tm)
+                p.activity-name
+                  = tm.name
+
+          article.lesson-name-and-description
+            header
+              h3.govuk-heading-m = slot.name
+
+            = markdown(slot.overview)
+
+            section.extra-requirements
+              - slot.extra_requirements.each do |er|
+                .govuk-tag.govuk-tag__grey = er
+
+            p.duration
+              | Approximately #{slot.duration} minutes
+
           - unless local_assigns[:mode] && mode == :print
-            th.govuk-table__header scope='col'
-              | Change activity
+            div.alternatives
+              div.alternatives-list
 
-      tbody.govuk-table__body
-        - @presenter.contents.each do |slot|
-          tr.govuk-table__row
-            th.govuk-table__cell.big-number
-              span.govuk-visually-hidden Lesson part number
-              = slot.counter
+                // example list for the time being
+                ul.govuk-list
+                  li Alternative One
+                  li Alternative Two
 
-            td.govuk-table__cell.activity-icons
-              ul.govuk-list
-                - slot.teaching_methods.each do |tm|
-                  li
-                    = activity_icon(tm)
-
-                    div
-                      = tm.name
-
-            td.main-content.govuk-table__cell
-              article
-                header
-                  h3.govuk-heading-m = slot.name
-                = markdown(slot.overview)
-              strong
-                | Approximately #{slot.duration} minutes
-              .files
-                / lp.file_formats.to_sentence
-                =< link_to 'Preview', '#'
-
-              section.extra-requirements
-                - slot.extra_requirements.each do |er|
-                  .govuk-tag = er
-            - unless local_assigns[:mode] && mode == :print
-              td.govuk-table__cell
-                - if slot.alternatives.any?
-                  ul.govuk-list
-                    - slot.alternatives.each do |alternative|
-                      li
-                        strong = alternative
-
+              div.change-link
                 = link_to 'Change activity', activity_choice_link(@current_teacher, slot.lesson_part_id)

--- a/app/views/teachers/lessons/show.slim
+++ b/app/views/teachers/lessons/show.slim
@@ -6,7 +6,7 @@
     h1.govuk-heading-l
       = @lesson.name
 
-    .govuk-tabs data-module="govuk-tabs"
+    .lesson-tabs.govuk-tabs data-module="govuk-tabs"
       h2.govuk-tabs__title
         | Lesson details
       ul.govuk-tabs__list
@@ -17,11 +17,12 @@
         li.govuk-tabs__list-item
           = link_to 'Downloads', '#downloads', class: 'govuk-tabs__tab'
 
-      section#knowledge-overview.govuk-tabs__panel
+      section#knowledge-overview.govuk-tabs__panel.lesson-tab
         h2
           =t(:heading, scope: :knowledge_overview)
 
         = markdown(@lesson.summary)
+
         = render 'core_knowledge', lesson: @lesson
         = render 'vocabulary', lesson: @lesson
         = render 'misconceptions', lesson: @lesson
@@ -29,7 +30,7 @@
 
         = secondary_button(teachers_lesson_path(@lesson.id, anchor: 'lesson-contents'), text: 'Lesson contents')
 
-      section#lesson-contents.govuk-tabs__panel
+      section#lesson-contents.govuk-tabs__panel.lesson-tab
         h2
           =t(:heading, scope: :lesson_contents)
 
@@ -37,7 +38,7 @@
 
         = secondary_button(teachers_lesson_path(@lesson.id, anchor: 'downloads'), text: 'Downloads')
 
-      section#downloads.govuk-tabs__panel
+      section#downloads.govuk-tabs__panel.lesson-tab
         h2 Downloads
 
         = render 'downloads', lesson: @lesson

--- a/app/webpacker/styles/_lessons.scss
+++ b/app/webpacker/styles/_lessons.scss
@@ -1,30 +1,140 @@
+$lesson-part-blue: #f0f9ff;
+$lesson-part-dark-blue: darken($lesson-part-blue, 15%);
+
+.lesson-tab {
+  @include govuk-media-query($from: tablet) {
+    border: 1px solid $lesson-part-dark-blue;
+    background-color: $lesson-part-blue;
+  }
+}
+
 .lesson-parts {
-  th {
-    background-color: govuk-tint(govuk-colour('turquoise'), 80);
-  }
+  align-items: center;
+  display: grid;
+  grid-gap: 1.5rem;
+  grid-template-columns: 1fr;
 
-  .files {
-    margin-bottom: 1rem;
-  }
+  .lesson-part {
+    background-color: govuk-colour('white');
+    border-radius: 5px;
+    display: grid;
+    grid-gap: 1rem;
+    grid-template-columns: 1fr 2fr 8fr 2fr;
 
-  .activity-icons {
-    padding: 0.5rem 1rem;
-    text-align: center;
+    .counter {
+      font-size: 4rem;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
 
-    ul {
-      > li {
-        margin: 1.5rem 0;
+    .teaching-methods {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      text-align: center;
+
+      .teaching-method {
+        margin: inherit inherit 0.5rem 0;
+
+        .activity-icon {
+          width: 70px;
+          height: 70px;
+        }
+
+        .activity-name {
+          text-align: center;
+          padding: 0;
+          margin: 0;
+          @include govuk-font($size: 14);
+        }
+      }
+    }
+
+    .lesson-name-and-description > header {
+      margin-top: 1rem;
+    }
+
+    .duration {
+      margin-top: 1rem;
+    }
+
+    .alternatives {
+      padding: 1rem 0.5rem 1rem 0;
+      @include govuk-font($size: 16);
+
+      display: flex;
+      flex-direction: column;
+
+      .alternatives-list {
+        flex-grow: 1;
       }
     }
   }
 
-  .extra-requirements {
-    .govuk-tag {
-      background-color: govuk-colour("dark-grey");
+  // when the screen is *narrower* than tablet
+  @include govuk-media-query($until: tablet) {
+    .lesson-part {
+      border-radius: 0;
+      padding: 1rem 0 1.5rem;
+      border-bottom: 1px solid govuk-colour("mid-grey");
 
-      &:not(:first-child) {
-        margin-left: 0.2rem;
+      // two columns
+      grid-template-columns: repeat(2, 1fr);
+      grid-template-rows: auto;
+
+      .counter {
+        justify-content: flex-start;
+      }
+
+      .teaching-methods {
+        flex-direction: row;
+        justify-content: flex-end;
+
+        .teaching-method {
+          &:not(:first-child) {
+            margin-left: 0.5rem;
+            margin-bottom: 0;
+
+            .activity-name {
+              @include govuk-font($size: 14);
+            }
+          }
+        }
+      }
+
+      // make the article - the part that includes the name and
+      // description - span the entire width of two columns
+      article,
+      .alternatives {
+        grid-column: 1 / span 2;
       }
     }
+  }
+
+  // when the screen is *wider* than tablet
+  @include govuk-media-query($from: tablet) {
+    .lesson-part {
+      .counter {
+        border-left: 8px solid $lesson-part-dark-blue;
+      }
+
+      .teaching-method {
+        &:not(:first-child) {
+          margin-left: 0;
+          margin-top: 1rem;
+
+          .activity-name {
+            @include govuk-font($size: 14);
+          }
+        }
+      }
+    }
+  }
+}
+
+.lesson-tabs {
+  .govuk-tabs__list-item.govuk-tabs__list-item--selected {
+    background-color: $lesson-part-blue;
   }
 }

--- a/app/webpacker/styles/_print.scss
+++ b/app/webpacker/styles/_print.scss
@@ -22,5 +22,13 @@
   #lesson-contents.govuk-tabs__panel {
     page-break-before: always;
   }
+
+  .teaching-method {
+    max-width: 250px !important;
+
+    img {
+      max-width: 250px !important;
+    }
+  }
 }
 // scss-lint:enable QualifyingElement IdSelector

--- a/app/webpacker/styles/_utility.scss
+++ b/app/webpacker/styles/_utility.scss
@@ -1,9 +1,14 @@
 // used for numbering sequences of units in a ccp, lessons
 // in a unit, etc
 .big-number {
-  font-size: 2.5rem;
+  @include govuk-font($size: 48, $weight: bold);
+  font-size: 4rem;
   color: govuk-shade(govuk-colour('dark-grey'), 10);
   text-align: center;
   padding: 0 0.5rem;
   vertical-align: middle;
+}
+
+.govuk-tag__grey {
+  background-color: govuk-colour('dark-grey');
 }

--- a/spec/features/lessons/lesson_contents_tab_spec.rb
+++ b/spec/features/lessons/lesson_contents_tab_spec.rb
@@ -12,20 +12,20 @@ RSpec.feature "Lesson contents tab", type: :feature do
     within('ul.govuk-tabs__list') { click_on 'Lesson contents' }
   end
 
-  specify 'the page should contain a table of lesson parts' do
-    expect(page).to have_css('table.lesson-parts')
+  specify 'the page should contain a list of lesson parts' do
+    expect(page).to have_css('.lesson-parts > .lesson-part')
   end
 
-  specify 'there should be one row per lesson part' do
-    within('table.lesson-parts > tbody') do
-      expect(page).to have_css('tr', count: lesson_part_count)
+  specify 'all lesson parts belonging to the lesson should be listed' do
+    within('.lesson-parts') do
+      expect(page).to have_css('.lesson-part', count: lesson_part_count)
     end
   end
 
   # FIXME it would probably make sense to hide the link
   #       when there are no alternative activities
   specify 'each part should have a change link' do
-    within('table.lesson-parts > tbody') do
+    within('.lesson-parts') do
       lesson_parts.each do |lesson_part|
         expect(page).to have_link('Change activity', href: new_teachers_lesson_part_choice_path(lesson_part.id))
       end

--- a/spec/features/lessons/print_spec.rb
+++ b/spec/features/lessons/print_spec.rb
@@ -15,7 +15,9 @@ RSpec.feature "Lesson print", type: :feature do
     end
 
     specify "the page contains the lesson activities" do
-      expect(page).to have_css('table.lesson-parts.govuk-table')
+      within('.lesson-parts') do
+        expect(page).to have_css('.lesson-part', count: lesson_part_count)
+      end
     end
 
     specify "the page doesn't contain the ability to change activities" do

--- a/spec/views/teachers/lessons/_lesson_contents.slim_spec.rb
+++ b/spec/views/teachers/lessons/_lesson_contents.slim_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe "teachers/lessons/_lesson_contents" do
 
   it "includes the lesson parts" do
     render
-    expect(rendered).to have_css('table.lesson-parts.govuk-table')
+    expect(rendered).to have_css('.lesson-parts')
     presenter.contents.each.with_index(1) do |slot, i|
-      expect(rendered).to have_css('th.govuk-table__cell.big-number', text: i)
+      expect(rendered).to have_css('.big-number', text: i)
       expect(rendered).to have_content(slot.name)
       expect(rendered).to have_content(slot.overview)
     end


### PR DESCRIPTION
### Context

The lesson contents page previously wasn't responsive, it didn't really work on mobile.

Also, change the tab 'theme' colour to blue to reflect the latest version of the prototype.

### Changes proposed in this pull request

Replace the table with 'cards' that condense nicely on a smaller screen

### Guidance to review

Ensure everything looks sensible

| Size | Before | After|
| ----- | -------- | ------ |
| Wide | ![Screenshot from 2020-03-03 14-12-40](https://user-images.githubusercontent.com/128088/75784043-826ee680-5d59-11ea-8b55-a68cacf698b1.png) | ![Screenshot from 2020-03-03 14-13-37](https://user-images.githubusercontent.com/128088/75784049-86026d80-5d59-11ea-98c1-e2c740325299.png) |
| Narrow | ![Screenshot from 2020-03-03 14-13-00](https://user-images.githubusercontent.com/128088/75784103-9a466a80-5d59-11ea-8410-82f02337ec51.png) |  ![Screenshot from 2020-03-03 14-13-54](https://user-images.githubusercontent.com/128088/75784114-9e728800-5d59-11ea-8a5d-bc26397b2b3f.png) |



