### PR TITLE
Add resource packager

### DIFF
--- a/app/jobs/download_job.rb
+++ b/app/jobs/download_job.rb
@@ -1,7 +1,15 @@
 class DownloadJob < ApplicationJob
   queue_as :default
 
-  def perform(*args)
-    # Do something later
+  def perform(download)
+    resource_packager = ResourcePackager.new(download)
+
+    download.lesson_bundle.attach(
+      io: resource_packager.lesson_bundle,
+      filename: "#{download.lesson.name.parameterize}.zip",
+      content_type: 'application/zip'
+    )
+
+    download.transition_to!(:completed)
   end
 end

--- a/app/models/download.rb
+++ b/app/models/download.rb
@@ -19,4 +19,8 @@ class Download < ApplicationRecord
   def state_machine
     @state_machine ||= DownloadStateMachine.new(self, transition_class: DownloadTransition)
   end
+
+  def lesson_parts
+    lesson.lesson_parts_for(teacher)
+  end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -15,4 +15,10 @@ class Lesson < ApplicationRecord
   def duration
     '1 hour'
   end
+
+  def lesson_parts_for(teacher)
+    lesson_parts
+      .each_with_object({}) { |lesson_part, hash| hash[lesson_part] = lesson_part.activity_for(teacher) }
+      .reject { |_, activity| activity.nil? }
+  end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -18,6 +18,7 @@ class Lesson < ApplicationRecord
 
   def lesson_parts_for(teacher)
     lesson_parts
+      .merge(LessonPart.ordered_by_position)
       .each_with_object({}) { |lesson_part, hash| hash[lesson_part] = lesson_part.activity_for(teacher) }
       .reject { |_, activity| activity.nil? }
   end

--- a/app/presenters/teachers/lesson_contents_presenter.rb
+++ b/app/presenters/teachers/lesson_contents_presenter.rb
@@ -20,9 +20,7 @@ module Teachers
 
     def initialize(lesson, teacher)
       @contents = lesson
-        .lesson_parts
-        .each_with_object({}) { |lesson_part, hash| hash[lesson_part] = lesson_part.activity_for(teacher) }
-        .reject { |_, activity| activity.nil? }
+        .lesson_parts_for(teacher)
         .map
         .with_index(1) { |(lesson_part, activity), i| Slot.new(i, lesson_part, activity) }
     end

--- a/app/utilities/resource_packager.rb
+++ b/app/utilities/resource_packager.rb
@@ -1,0 +1,47 @@
+require 'zip'
+
+class ResourcePackager
+  attr_accessor :download
+
+  def initialize(download)
+    @download     = download
+    @lesson_parts = download.lesson_parts
+  end
+
+  def lesson_bundle
+    build_lesson_bundle.tap(&:rewind)
+  end
+
+private
+
+  def activities
+    @lesson_parts.values
+  end
+
+  def combined_slide_deck
+    # TODO retrieve the combined slide deck
+    # activities.map { |activity| activity.slide_deck }
+  end
+
+  def pupil_resource_blobs
+    activities.map(&:pupil_resources).flat_map(&:blobs)
+  end
+
+  def teacher_resource_blobs
+    activities.map(&:teacher_resources).flat_map(&:blobs)
+  end
+
+  def build_lesson_bundle
+    Zip::OutputStream.write_buffer do |zip|
+      teacher_resource_blobs.each { |blob| add_to_zip(zip, blob, resource_type: 'teacher') }
+      pupil_resource_blobs.each   { |blob| add_to_zip(zip, blob, resource_type: 'pupil') }
+
+      # TODO add the combined_slide_deck
+    end
+  end
+
+  def add_to_zip(zip, blob, resource_type:)
+    zip.put_next_entry(File.join(resource_type, blob.filename.to_s))
+    zip.write(blob.download)
+  end
+end

--- a/spec/jobs/download_job_spec.rb
+++ b/spec/jobs/download_job_spec.rb
@@ -1,5 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe DownloadJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:download) { create(:download) }
+
+  describe '#perform_later' do
+    before { ActiveJob::Base.queue_adapter = :test }
+
+    it "enqueues jobs" do
+      expect { DownloadJob.perform_later(download) }.to have_enqueued_job
+    end
+  end
+
+  describe '#perform' do
+    subject! { DownloadJob.perform_now(download) }
+
+    before { allow(download.lesson_bundle).to receive(:attach).and_return(1) }
+
+    # awaiting factories with attachments before testing the
+    # actual attachment process
+    xit "attaches the lesson bundle" do
+      expect(download.lesson_bundle).to have_received(:attach).with(:something)
+    end
+
+    it "progresses the state to :completed" do
+      expect(download.reload.state_machine).to be_in_state(:completed)
+    end
+  end
 end

--- a/spec/models/download_spec.rb
+++ b/spec/models/download_spec.rb
@@ -20,26 +20,47 @@ describe Download, type: :model do
     end
   end
 
-  context '#lesson_bundle' do
-    let :download do
-      create :download
+  describe 'methods' do
+    describe '#lesson_parts' do
+      subject { create(:download) }
+      let(:teacher) { subject.teacher }
+
+      before do
+        allow(subject.lesson).to(
+          receive(:lesson_parts_for)
+            .with(teacher)
+            .and_return([])
+        )
+      end
+
+      before { subject.lesson_parts }
+
+      it "should use Lesson#lesson_parts_for with assigned lesson and teacher" do
+        expect(subject.lesson).to have_received(:lesson_parts_for).with(teacher)
+      end
     end
 
-    before do
-      download.lesson_bundle.attach \
-        io: File.open(lesson_bundle_path),
-        filename: 'lesson_bundle.zip',
-        content_type: 'application/zip'
-    end
+    context '#lesson_bundle' do
+      let :download do
+        create :download
+      end
 
-    subject { download.lesson_bundle }
+      before do
+        download.lesson_bundle.attach \
+          io: File.open(lesson_bundle_path),
+          filename: 'lesson_bundle.zip',
+          content_type: 'application/zip'
+      end
 
-    it { is_expected.to be_attached }
+      subject { download.lesson_bundle }
 
-    it "is attached correctly" do
-      expect(subject.filename).to eq 'lesson_bundle.zip'
-      expect(subject.content_type).to eq 'application/zip'
-      expect(subject.download).to eq File.binread(lesson_bundle_path)
+      it { is_expected.to be_attached }
+
+      it "is attached correctly" do
+        expect(subject.filename).to eq 'lesson_bundle.zip'
+        expect(subject.content_type).to eq 'application/zip'
+        expect(subject.download).to eq File.binread(lesson_bundle_path)
+      end
     end
   end
 

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -26,4 +26,40 @@ RSpec.describe Lesson, type: :model do
     it { is_expected.to belong_to(:unit) }
     it { is_expected.to have_many :lesson_parts }
   end
+
+  describe 'methods' do
+    describe '#lesson_parts_for' do
+      let(:teacher) { create(:teacher) }
+      it { is_expected.to respond_to(:lesson_parts_for).with(1).argument }
+
+      let(:lesson_parts_with_activities) do
+        4.times.map do
+          double(LessonPart, activity_for: build(:activity))
+        end
+      end
+
+      let(:lesson_parts_without_activities) do
+        3.times.map do
+          double(LessonPart, activity_for: nil)
+        end
+      end
+
+      let(:lesson_parts) { lesson_parts_with_activities + lesson_parts_without_activities }
+
+      subject { create(:lesson) }
+
+      before do
+        allow(subject).to receive(:lesson_parts).and_return(lesson_parts)
+      end
+
+      specify 'should call LessonPart#activity_for for every lesson part' do
+        subject.lesson_parts_for(teacher)
+        expect(subject.lesson_parts).to all(have_received(:activity_for).with(teacher))
+      end
+
+      specify 'should only return lesson_part and activity pairs' do
+        expect(subject.lesson_parts_for(teacher).size).to be(lesson_parts_with_activities.size)
+      end
+    end
+  end
 end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -32,33 +32,19 @@ RSpec.describe Lesson, type: :model do
       let(:teacher) { create(:teacher) }
       it { is_expected.to respond_to(:lesson_parts_for).with(1).argument }
 
-      let(:lesson_parts_with_activities) do
-        4.times.map do
-          double(LessonPart, activity_for: build(:activity))
-        end
-      end
-
-      let(:lesson_parts_without_activities) do
-        3.times.map do
-          double(LessonPart, activity_for: nil)
-        end
-      end
-
-      let(:lesson_parts) { lesson_parts_with_activities + lesson_parts_without_activities }
-
       subject { create(:lesson) }
 
-      before do
-        allow(subject).to receive(:lesson_parts).and_return(lesson_parts)
+      let!(:lesson_parts_with_activities) do
+        create_list(:lesson_part, 2, :with_activities, lesson: subject)
       end
 
-      specify 'should call LessonPart#activity_for for every lesson part' do
-        subject.lesson_parts_for(teacher)
-        expect(subject.lesson_parts).to all(have_received(:activity_for).with(teacher))
+      let!(:lesson_parts_without_activities) do
+        create_list(:lesson_part, 3, lesson: subject)
       end
 
       specify 'should only return lesson_part and activity pairs' do
-        expect(subject.lesson_parts_for(teacher).size).to be(lesson_parts_with_activities.size)
+        lesson_parts_for_teacher = subject.lesson_parts_for(teacher)
+        expect(lesson_parts_for_teacher.keys.map(&:id)).to match_array(lesson_parts_with_activities.map(&:id))
       end
     end
   end

--- a/spec/utilities/resource_packager_spec.rb
+++ b/spec/utilities/resource_packager_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe(ResourcePackager) do
+  let(:download) { create(:download) }
+
+  subject { ResourcePackager.new(download) }
+
+  it { is_expected.to respond_to(:download) }
+  it { is_expected.to respond_to(:lesson_bundle) }
+
+  describe '#lesson_bundle' do
+    let(:activity) { create(:activity) }
+    let(:teacher_attachments) do
+      [{ filename: '1px.png', content_type: 'image/png' }]
+    end
+
+    let(:pupil_attachments) do
+      [{ filename: '1px.png', content_type: 'image/png' }]
+    end
+
+    before do
+      teacher_attachments.each do |attachment|
+        activity.teacher_resources.attach(
+          io: File.open(Rails.root.join('spec', 'fixtures', attachment[:filename])),
+          filename: attachment[:filename],
+          content_type: attachment[:content_type]
+        )
+      end
+
+      pupil_attachments.each do |attachment|
+        activity.pupil_resources.attach(
+          io: File.open(Rails.root.join('spec', 'fixtures', attachment[:filename])),
+          filename: attachment[:filename],
+          content_type: attachment[:content_type]
+        )
+      end
+    end
+
+    let(:teacher_attachment_filenames) do
+      teacher_attachments.map { |ta| ta[:filename] }
+    end
+
+    let(:pupil_attachment_filenames) do
+      pupil_attachments.map { |ta| ta[:filename] }
+    end
+
+    let(:download) { create(:download, lesson: activity.lesson_part.lesson) }
+    subject { ResourcePackager.new(download).lesson_bundle }
+
+    def strip_paths(entries)
+      entries.map { |tr| File.basename(tr) }
+    end
+
+    specify 'all attachments should be added to the zip file' do
+      Zip::File.open_buffer(subject) do |zip|
+        teacher_resources, pupil_resources = *zip.map(&:name).partition do |p|
+          p.starts_with?('teacher')
+        end
+
+        expect(teacher_attachment_filenames).to match_array(strip_paths(teacher_resources))
+        expect(pupil_attachment_filenames).to match_array(strip_paths(pupil_resources))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

When teachers have made a choice of activities for a lesson and hit 'Download' we need to serve them a single zip file that contains:
* Teacher resources
* Pupil resources
* Activity slide deck

### Changes proposed in this pull request

Build a `ResourcePackager` utility that is instantiated with a `Download` and allows the building of a zip file with the contents detailed above. Modify the `DownloadJob` to use the `ResourcePackager` to do this, save the attachment and mark the `Download` as complete

### Guidance to review

Ensure everything looks sensible and is integratable with the components around it.
