### PR TITLE
Fix for IE11, hide icons and fall back to default

### DIFF
--- a/app/webpacker/styles/_lessons.scss
+++ b/app/webpacker/styles/_lessons.scss
@@ -10,6 +10,7 @@ $lesson-part-dark-blue: darken($lesson-part-blue, 15%);
 
 .lesson-parts {
   align-items: center;
+
   display: grid;
   grid-gap: 1.5rem;
   grid-template-columns: 1fr;
@@ -17,15 +18,25 @@ $lesson-part-dark-blue: darken($lesson-part-blue, 15%);
   .lesson-part {
     background-color: govuk-colour('white');
     border-radius: 5px;
-    display: grid;
-    grid-gap: 1rem;
-    grid-template-columns: 1fr 2fr 8fr 2fr;
+
+    @supports (display: grid) {
+      display: grid;
+      grid-gap: 1rem;
+      grid-template-columns: 1fr 2fr 8fr 2fr;
+    }
+
+    // grid will take priority and fall back to
+    // flex for older browsers (lookin' at you, IE11)
+    display: flex;
+    flex-direction: row;
+    flex-flow: column-wrap;
 
     .counter {
       font-size: 4rem;
       display: flex;
       justify-content: center;
       align-items: center;
+      flex-shrink: 0;
     }
 
     .teaching-methods {
@@ -33,6 +44,8 @@ $lesson-part-dark-blue: darken($lesson-part-blue, 15%);
       flex-direction: column;
       justify-content: center;
       text-align: center;
+      flex-shrink: 0;
+      flex-basis: 150px;
 
       .teaching-method {
         margin: inherit inherit 0.5rem 0;
@@ -40,6 +53,7 @@ $lesson-part-dark-blue: darken($lesson-part-blue, 15%);
         .activity-icon {
           width: 70px;
           height: 70px;
+          display: inline;
         }
 
         .activity-name {
@@ -117,6 +131,7 @@ $lesson-part-dark-blue: darken($lesson-part-blue, 15%);
     .lesson-part {
       .counter {
         border-left: 8px solid $lesson-part-dark-blue;
+        padding-left: 2rem;
       }
 
       .teaching-method {


### PR DESCRIPTION
IE11 supports an older version of CSS Grid that isn't compatible with the current one. To improve the experience for IE11 users (1-2%) add a Flexbox fallback. This looks _broadly_ the same as the Grid implementation except, due to the lack of subgrids, doesn't support inter-row alignment (meaning the columns might not always perfectly line up)

An example of the lack of alignment can be seen in this screenshot. The page is still perfectly legible and useable, and it stil collapses nicely when viewed on narrower screens.

![Screenshot from 2020-03-05 20-09-53](https://user-images.githubusercontent.com/128088/76023904-0a075180-5f22-11ea-8616-fbdefe9187bc.png)
