### PR TITLE
Add alternatives list

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -43,6 +43,6 @@ class Activity < ApplicationRecord
   scope :omit, ->(activity) { where.not(id: activity.id) }
 
   def alternatives
-    [] # TODO return siblings
+    lesson_part.activities.omit(self)
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -40,6 +40,8 @@ class Activity < ApplicationRecord
             content_type: SLIDE_DECK_CONTENT_TYPE,
             size: { less_than: MAX_UPLOAD_SIZE }
 
+  scope :omit, ->(activity) { where.not(id: activity.id) }
+
   def alternatives
     [] # TODO return siblings
   end

--- a/app/views/teachers/lessons/_lesson_contents.slim
+++ b/app/views/teachers/lessons/_lesson_contents.slim
@@ -50,6 +50,7 @@ section
             - if slot.alternatives.any?
               div.alternatives
                 div.alternatives-list
+                  h4 Alternative activities:
 
                   ul.govuk-list.govuk-list--bullet
                     - slot.alternatives.each do |alternative|

--- a/app/views/teachers/lessons/_lesson_contents.slim
+++ b/app/views/teachers/lessons/_lesson_contents.slim
@@ -46,13 +46,18 @@ section
               | Approximately #{slot.duration} minutes
 
           - unless local_assigns[:mode] && mode == :print
-            div.alternatives
-              div.alternatives-list
 
-                // example list for the time being
-                ul.govuk-list
-                  li Alternative One
-                  li Alternative Two
+            - if slot.alternatives.any?
+              div.alternatives
+                div.alternatives-list
 
-              div.change-link
-                = link_to 'Change activity', activity_choice_link(@current_teacher, slot.lesson_part_id)
+                  ul.govuk-list.govuk-list--bullet
+                    - slot.alternatives.each do |alternative|
+                      li = alternative.name
+
+                div.change-link
+                  = link_to 'Change activity', activity_choice_link(@current_teacher, slot.lesson_part_id)
+
+            - else
+              div.govuk-hint.no-alternatives
+                | No alternatives

--- a/app/webpacker/styles/_lessons.scss
+++ b/app/webpacker/styles/_lessons.scss
@@ -74,8 +74,7 @@ $lesson-part-dark-blue: darken($lesson-part-blue, 15%);
     }
 
     .alternatives {
-      padding: 1rem 0.5rem 1rem 0;
-      @include govuk-font($size: 16);
+      padding: 1rem;
 
       display: flex;
       flex-direction: column;
@@ -83,6 +82,10 @@ $lesson-part-dark-blue: darken($lesson-part-blue, 15%);
       .alternatives-list {
         flex-grow: 1;
       }
+    }
+
+    .no-alternatives {
+      padding: 1rem;
     }
   }
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -165,4 +165,17 @@ RSpec.describe Activity, type: :model do
       end
     end
   end
+
+  describe 'methods' do
+    describe '#alternatives' do
+      it { is_expected.to respond_to(:alternatives) }
+
+      let(:current_activity) { create(:activity) }
+      let(:other_activities) { create(:activity, lesson_part: current_activity.lesson_part) }
+
+      specify 'returns siblings but not self' do
+        expect(current_activity.alternatives).to match_array(other_activities)
+      end
+    end
+  end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -150,4 +150,19 @@ RSpec.describe Activity, type: :model do
       end
     end
   end
+
+  describe 'scopes' do
+    describe '.omit' do
+      let(:activities) { create_list(:activity, 2) }
+      let(:unwanted_activity) { create(:activity) }
+
+      specify 'the unwanted activity should be omitted' do
+        expect(Activity.omit(unwanted_activity)).not_to include(unwanted_activity)
+      end
+
+      specify 'the other activities should be present' do
+        expect(Activity.omit(unwanted_activity)).to match_array(activities)
+      end
+    end
+  end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Activity, type: :model do
     end
   end
 
-  context 'attachements' do
+  context 'attachments' do
     let :attachment_path do
       File.join(Rails.application.root, 'spec', 'fixtures', '1px.png')
     end

--- a/spec/presenters/teachers/lesson_contents_presenter_spec.rb
+++ b/spec/presenters/teachers/lesson_contents_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Teachers::LessonContentsPresenter do
         expect(slot.duration).to eql(activity.duration)
         expect(slot.overview).to eql(activity.overview)
         expect(slot.extra_requirements).to eql(activity.extra_requirements)
-        expect(slot.alternatives).to eql(activity.alternatives)
+        expect(slot.alternatives).to match_array(activity.alternatives)
         expect(slot.teaching_methods).to match_array(activity.teaching_methods)
 
         expect(slot.lesson_part_id).to eql(lesson_part.id)

--- a/spec/views/teachers/lessons/_lesson_contents.slim_spec.rb
+++ b/spec/views/teachers/lessons/_lesson_contents.slim_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "teachers/lessons/_lesson_contents" do
+  let(:number_of_parts) { 2 }
   let(:lesson) { FactoryBot.create(:lesson) }
   let(:teacher) { FactoryBot.create(:teacher) }
-  let!(:lesson_parts) { FactoryBot.create_list(:lesson_part, 2, :with_activities, lesson: lesson) }
+  let!(:lesson_parts) { FactoryBot.create_list(:lesson_part, number_of_parts, :with_activities, lesson: lesson) }
   let(:presenter) { Teachers::LessonContentsPresenter.new(lesson, teacher) }
 
   before :each do
@@ -31,6 +32,29 @@ RSpec.describe "teachers/lessons/_lesson_contents" do
     render
     expect(rendered).to have_css('div.govuk-warning-text__text', text: "This lesson has no activities")
     expect(rendered).not_to have_css('table.lesson-parts.govuk-table')
+  end
+
+  describe 'alternatives' do
+    before { render }
+
+    context 'when there are alternatives' do
+      specify %(they should be listed) do
+        lesson_parts
+          .map { |lp| lp.activity_for(teacher) }
+          .map(&:alternatives)
+          .each do |alternative|
+            expect(rendered).to have_css('li', text: alternative.name)
+          end
+      end
+    end
+
+    context 'when there no alternatives' do
+      let!(:lesson_parts) { FactoryBot.create_list(:lesson_part, number_of_parts, :with_activities, number_of_activities: 1, lesson: lesson) }
+
+      specify %("No alternatives" should be displayed) do
+        expect(rendered).to have_content(%(No alternatives), count: number_of_parts)
+      end
+    end
   end
 
   context "mode: :print" do


### PR DESCRIPTION
Added the alternatives list that replaces hardcoded "Alternative 1" text.

The design isn't _finalised_, the list is too big and wordy alternatives don't exactly read well, but it's a starting point.

![Screenshot from 2020-03-09 13-43-35](https://user-images.githubusercontent.com/128088/76234655-ebef6900-6221-11ea-958f-c3d25aaed0dd.png)
