### PR TITLE
Cmb 614/hide download if nothing to download

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -32,4 +32,8 @@ class Activity < ApplicationRecord
   def make_default!
     lesson_part.update!(default_activity: self)
   end
+
+  def has_lesson_resources?
+    [teacher_resources, pupil_resources, slide_deck_resource].any?(&:present?)
+  end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -22,4 +22,8 @@ class Lesson < ApplicationRecord
       .each_with_object({}) { |lesson_part, hash| hash[lesson_part] = lesson_part.activity_for(teacher) }
       .reject { |_, activity| activity.nil? }
   end
+
+  def activities_for(teacher)
+    lesson_parts_for(teacher).values
+  end
 end

--- a/app/presenters/teachers/lesson_contents_presenter.rb
+++ b/app/presenters/teachers/lesson_contents_presenter.rb
@@ -39,6 +39,10 @@ module Teachers
         .with_index(1) { |(lesson_part, activity), i| Slot.new(i, lesson_part, activity) }
     end
 
+    def show_download_link?
+      @lesson.activities_for(@teacher).any?(&:has_lesson_resources?)
+    end
+
   private
 
     def load_parts

--- a/app/views/teachers/lessons/_downloads.slim
+++ b/app/views/teachers/lessons/_downloads.slim
@@ -1,10 +1,8 @@
-section.downloads
-  h2.govuk-heading-l Download the lesson plan and resources
+p
+  | You can download the lesson plan and resources you'll need to
+    teach the lesson (for example, worksheets and presentation
+    slides).
 
-  p
-    | You can download the lesson plan and resources you'll need to
-      teach the lesson (for example, worksheets and presentation
-      slides).
+p = link_to("Print lesson plan", print_teachers_lesson_path(lesson: lesson, auto_print: true), target: "_blank")
 
-  p = link_to("Print lesson plan", print_teachers_lesson_path(lesson: @lesson, auto_print: true), target: "_blank")
-  p = button_to 'Download lesson resources', teachers_lesson_downloads_path(@lesson), class: 'govuk-button'
+p = button_to 'Download lesson resources', teachers_lesson_downloads_path(lesson), class: 'govuk-button'

--- a/app/views/teachers/lessons/_downloads_print_only.slim
+++ b/app/views/teachers/lessons/_downloads_print_only.slim
@@ -1,0 +1,3 @@
+p You can print the lesson plan you'll need to teach this lesson.
+
+p = link_to("Print lesson plan", print_teachers_lesson_path(lesson: lesson, auto_print: true), target: "_blank", class: 'govuk-button')

--- a/app/views/teachers/lessons/_downloads_print_only.slim
+++ b/app/views/teachers/lessons/_downloads_print_only.slim
@@ -1,3 +1,5 @@
-p You can print the lesson plan you'll need to teach this lesson.
+p
+  | There are no resources to download for this lesson.
+    You can print the lesson plan you’ll need to teach this lesson.
 
 p = link_to("Print lesson plan", print_teachers_lesson_path(lesson: lesson, auto_print: true), target: "_blank", class: 'govuk-button')

--- a/app/views/teachers/lessons/show.slim
+++ b/app/views/teachers/lessons/show.slim
@@ -45,5 +45,15 @@
         = secondary_button(teachers_lesson_path(@lesson.id, anchor: 'downloads'), text: 'Download resources', number: 3)
 
       section#downloads.govuk-tabs__panel.lesson-tab
-        = render 'downloads', lesson: @lesson
-        = render 'plan_the_next_lesson', lesson: @lesson
+        section.downloads
+          - if @presenter.show_download_link?
+            h2.govuk-heading-l Download the lesson plan and resources
+
+            = render "downloads", lesson: @lesson
+            = render "plan_the_next_lesson", lesson: @lesson
+
+          - else
+
+            h2.govuk-heading-l Print this lesson plan
+            = render "downloads_print_only", lesson: @lesson
+            = render "plan_the_next_lesson", lesson: @lesson

--- a/spec/features/lessons/downloads_tab_spec.rb
+++ b/spec/features/lessons/downloads_tab_spec.rb
@@ -1,47 +1,71 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.feature "Downloads tab", type: :feature do
   include_context 'logged in teacher'
 
-  let(:lesson) { FactoryBot.create(:lesson) }
-
   before { visit(teachers_lesson_path(lesson)) }
 
-  specify %(the tab's main heading should be 'Download the lesson plan and resources') do
-    within('#downloads') { expect(page).to have_css('h2', text: 'Download the lesson plan and resources') }
-  end
-
-  specify %(there should be a 'Print lesson plan' link) do
-    within('#downloads') { expect(page).to have_link('Print lesson plan') }
-  end
-
-  specify %(there should be a 'Download lesson resources' button) do
-    within('#downloads') { expect(page).to have_button('Download lesson resources') }
-  end
-
-  specify %(there should be a 'Go to next lesson' link) do
-    expect(page).to \
-      have_link('Go to next lesson', href: teachers_unit_path(lesson.unit))
-  end
-
-  context 'Download lesson resources' do
-    before do
-      click_button 'Download lesson resources'
+  context %(when the lesson has resources to download) do
+    let(:activity) { create :activity, :with_slide_deck }
+    let(:lesson) { activity.lesson_part.lesson }
+    specify %(the tab's main heading should be 'Download the lesson plan and resources') do
+      within('#downloads') { expect(page).to have_css('h2', text: 'Download the lesson plan and resources') }
     end
 
-    specify "it should redirect to the download page" do
-      expect(page.current_path).to eq \
-        teachers_download_path(teacher.downloads.last)
+    specify %(there should be a 'Print lesson plan' link) do
+      within('#downloads') { expect(page).to have_link('Print lesson plan') }
+    end
+
+    specify %(there should be a 'Download lesson resources' button) do
+      within('#downloads') { expect(page).to have_button('Download lesson resources') }
+    end
+
+    specify %(there should be a 'Go to next lesson' link) do
+      expect(page).to \
+        have_link('Go to next lesson', href: teachers_unit_path(lesson.unit))
+    end
+
+    context 'Download lesson resources' do
+      before { click_button 'Download lesson resources' }
+
+      specify "it should redirect to the download page" do
+        expect(page.current_path).to eq \
+          teachers_download_path(teacher.downloads.last)
+      end
+    end
+
+    context 'Print lesson plan' do
+      before { click_link 'Print lesson plan' }
+
+      specify "it should redirect to the print lesson page" do
+        expect(page.current_path).to eq print_teachers_lesson_path(lesson)
+      end
     end
   end
 
-  context 'Print lesson plan' do
-    before do
-      click_link 'Print lesson plan'
+  context %(when the lesson dosen't have resources to download) do
+    let(:activity) { create :activity }
+    let(:lesson) { activity.lesson_part.lesson }
+
+    specify %(the tab's main heading should be 'Downloads') do
+      within('#downloads') { expect(page).to have_css('h2', text: 'Print this lesson plan') }
     end
 
-    specify "it should redirect to the print lesson page" do
-      expect(page.current_path).to eq print_teachers_lesson_path(lesson)
+    specify %(there should be a 'Print lesson plan' link) do
+      within('#downloads') { expect(page).to have_link('Print lesson plan') }
+    end
+
+    specify %(there should be a 'Go to next lesson' link) do
+      expect(page).to \
+        have_link('Go to next lesson', href: teachers_unit_path(lesson.unit))
+    end
+
+    context 'Print lesson plan' do
+      before { click_link 'Print lesson plan' }
+
+      specify "it should redirect to the print lesson page" do
+        expect(page.current_path).to eq print_teachers_lesson_path(lesson)
+      end
     end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -92,5 +92,33 @@ RSpec.describe Activity, type: :model do
         expect(current_activity.alternatives).to match_array(other_activities)
       end
     end
+
+    context '#has_lesson_resources?' do
+      subject { activity.has_lesson_resources? }
+
+      context 'when has attached teacher_resources' do
+        let(:activity) { create :activity, :with_teacher_resources }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when has attached pupil_resources' do
+        let(:activity) { create :activity, :with_pupil_resources }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when has attached slide_deck' do
+        let(:activity) { create :activity, :with_slide_deck }
+
+        it { is_expected.to be true }
+      end
+
+      context 'with out attached resources' do
+        let(:activity) { create :activity }
+
+        it { is_expected.to be false }
+      end
+    end
   end
 end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -47,6 +47,59 @@ RSpec.describe Lesson, type: :model do
         expect(lesson_parts_for_teacher.keys.map(&:id)).to match_array(lesson_parts_with_activities.map(&:id))
       end
     end
+
+    describe '#activities_for' do
+      let! :teacher do
+        create :teacher
+      end
+
+      let! :lesson do
+        create :lesson
+      end
+
+      let! :lesson_part_1 do
+        create :lesson_part, lesson: lesson
+      end
+
+      let! :lesson_part_2 do
+        create :lesson_part, lesson: lesson
+      end
+
+      let! :lesson_part_3 do
+        create :lesson_part, lesson: lesson
+      end
+
+      let! :lesson_part_4 do
+        create :lesson_part, lesson: lesson
+      end
+
+      let! :activity_with_pupil_resource do
+        create :activity, :with_pupil_resources, lesson_part: lesson_part_1
+      end
+
+      let! :activity_with_teacher_resource do
+        create :activity, :with_teacher_resources, lesson_part: lesson_part_2
+      end
+
+      let! :activity_with_slide_deck do
+        create :activity, :with_slide_deck, lesson_part: lesson_part_3
+      end
+
+      let! :activity_with_no_resource do
+        create :activity, lesson_part: lesson_part_4
+      end
+
+      subject { lesson.reload.activities_for teacher }
+
+      it do
+        is_expected.to match_array [
+          activity_with_pupil_resource,
+          activity_with_teacher_resource,
+          activity_with_slide_deck,
+          activity_with_no_resource
+        ]
+      end
+    end
   end
 
   describe 'scopes' do

--- a/spec/presenters/teachers/lesson_contents_presenter_spec.rb
+++ b/spec/presenters/teachers/lesson_contents_presenter_spec.rb
@@ -50,6 +50,24 @@ RSpec.describe Teachers::LessonContentsPresenter do
     end
   end
 
+  context '#show_download_link?' do
+    subject do
+      described_class.new(activity.lesson_part.lesson, teacher).show_download_link?
+    end
+
+    context 'when the lesson has at least one activity with resources' do
+      let(:activity) { create :activity, :with_pupil_resources }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the lesson no activities with resources' do
+      let(:activity) { create :activity }
+
+      it { is_expected.to be false }
+    end
+  end
+
   context 'Slot#resources' do
     let :activity do
       create :activity

--- a/spec/views/teachers/lessons/show.slim_spec.rb
+++ b/spec/views/teachers/lessons/show.slim_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'teachers/lessons/show' do
+  let(:teacher) { create :teacher }
+  let(:presenter) { Teachers::LessonContentsPresenter.new lesson, teacher }
+
+  before do
+    controller.request.path_parameters[:id] = lesson.id # For path helpers
+    assign :lesson, lesson
+    assign :presenter, presenter
+  end
+
+  subject { render }
+
+  context 'show_download_link' do
+    let(:lesson) { create(:activity, :with_pupil_resources).lesson_part.lesson }
+
+    it { is_expected.to have_button 'Download lesson resources' }
+    it { is_expected.to have_link 'Print lesson plan' }
+  end
+
+  context "don't show_download_link" do
+    let(:lesson) { create :lesson }
+
+    it { is_expected.not_to have_button 'Download lesson resources' }
+    it { is_expected.to include 'There are no resources to download for this lesson' }
+    it { is_expected.to have_link 'Print lesson plan', class: 'govuk-button' }
+  end
+end


### PR DESCRIPTION
NOTE rebase off development once preview #117 and polling #119 prs are merged

### Context
In the case that a teacher has chosen activities that don't have any
resources (activities for PE?) then the lesson_bundle zip will be empty.
To avoid this confusion we'll hide the download button if there is
nothing to download and instead only offer the option to print the
lesson plan.

### Changes proposed in this pull request
Hides the download button if the selected activities have no resources to download
<img width="959" alt="lesson-with-resources" src="https://user-images.githubusercontent.com/9936028/76322383-397bdc80-62db-11ea-85a4-144586824626.png">
<img width="961" alt="lesson-without-resources" src="https://user-images.githubusercontent.com/9936028/76322386-3bde3680-62db-11ea-9cdc-0876979cdfed.png">


### Guidance to review
Select activities that have no resources to download, head to the downloads tab expect there to be a print lesson plan button but no download button.
