### PR TITLE
Fix yarn integrity issue when running in dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-node_modules
+/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - DB_PASSWORD=secret
     volumes:
       - .:/usr/src/app
-      - node_modules:/usr/src/app/node_modules
+      - /usr/src/app/node_modules/
     depends_on:
       - db_tasks
 
@@ -43,4 +43,3 @@ services:
 
 volumes:
   db_data:
-  node_modules:


### PR DESCRIPTION
### Context
Yarn integrity check was blowing up when running the app in dev mode in docker.

### Changes proposed in this pull request
Fix yarn integrity check by not using named volume.

### Guidance to review
Running docker-compose up should work without error
