### PR TITLE
Stop Rails' warnings on component instances

### DIFF
--- a/app/components/activities/preview_resource_link.rb
+++ b/app/components/activities/preview_resource_link.rb
@@ -2,7 +2,7 @@ module Activities
   class PreviewResourceLink < ActionView::Component::Base
     attr_reader :resource
 
-    def initialize(resource)
+    def initialize(resource:)
       @resource = resource
     end
 

--- a/app/views/teachers/lessons/_preview.slim
+++ b/app/views/teachers/lessons/_preview.slim
@@ -6,7 +6,7 @@
 
     .govuk-details__text
       - resources.each do |resource|
-        = render(Activities::PreviewResourceLink, resource)
+        = render(Activities::PreviewResourceLink, resource: resource)
 
 - elsif resources.one?
-  = render(Activities::PreviewResourceLink, resources.first)
+  = render(Activities::PreviewResourceLink, resource: resources.first)

--- a/spec/components/activities/preview_resource_link_spec.rb
+++ b/spec/components/activities/preview_resource_link_spec.rb
@@ -11,7 +11,7 @@ describe Activities::PreviewResourceLink, type: :component do
 
   context 'generated HTML' do
     let :page do
-      Capybara::Node::Simple.new(render_inline(described_class.new(resource)))
+      Capybara::Node::Simple.new(render_inline(described_class, resource: resource))
     end
 
     it 'renders the correct link' do


### PR DESCRIPTION
Using a keyword argument allows us to call render the same way in templates and tests without emitting warnings