### PR TITLE
Add position to the lesson seed attributes

### DIFF
--- a/db/seeds/seeders/lesson_seeder.rb
+++ b/db/seeds/seeders/lesson_seeder.rb
@@ -41,7 +41,8 @@ module Seeders
         name: @name,
         previous_knowledge: @previous_knowledge,
         summary: @summary,
-        vocabulary: @vocabulary
+        vocabulary: @vocabulary,
+        position: @position
       }
     end
 


### PR DESCRIPTION
Seeded lesson weren't ordered correctly because the position was omitted from the seeding attributes :man_facepalming: 