### PR TITLE
Adds resource models

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -15,6 +15,23 @@ class Activity < ApplicationRecord
   has_many :activity_teaching_methods, dependent: :destroy
   has_many :activity_choices, dependent: :destroy
   has_many :teaching_methods, through: :activity_teaching_methods
+  has_many :temp_teacher_resources,
+           -> { where type: 'TeacherResource' },
+           class_name: 'TeacherResource',
+           dependent: :destroy,
+           inverse_of: :activity
+
+  has_many :temp_pupil_resources,
+           -> { where type: 'PupilResource' },
+           class_name: 'PupilResource',
+           dependent: :destroy,
+           inverse_of: :activity
+
+  has_one :temp_slide_deck,
+          -> { where type: 'SlideDeckResource' },
+          class_name: 'SlideDeckResource',
+          dependent: :destroy,
+          inverse_of: :activity
 
   has_many_attached :teacher_resources
   has_many_attached :pupil_resources

--- a/app/models/pupil_resource.rb
+++ b/app/models/pupil_resource.rb
@@ -1,0 +1,23 @@
+class PupilResource < Resource
+  ALLOWED_CONTENT_TYPES = %w(
+    application/pdf
+    application/vnd.oasis.opendocument.text
+    application/vnd.oasis.opendocument.presentation
+    image/gif
+    image/jpeg
+    image/jpg
+    image/png
+  ).freeze
+
+  MAX_UPLOAD_SIZE = 50.megabytes
+
+  validates :type, inclusion: %w(PupilResource).freeze
+
+  validates :file,
+            content_type: ALLOWED_CONTENT_TYPES,
+            size: { less_than: MAX_UPLOAD_SIZE }
+
+  validates :preview,
+            content_type: 'image/png',
+            size: { less_than: MAX_UPLOAD_SIZE }
+end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,0 +1,5 @@
+class Resource < ApplicationRecord
+  belongs_to :activity
+  has_one_attached :file
+  has_one_attached :preview
+end

--- a/app/models/slide_deck_resource.rb
+++ b/app/models/slide_deck_resource.rb
@@ -1,0 +1,14 @@
+class SlideDeckResource < Resource
+  ALLOWED_CONTENT_TYPES = %w(application/vnd.oasis.opendocument.presentation).freeze
+  MAX_UPLOAD_SIZE = 50.megabytes
+
+  validates :type, inclusion: %w(SlideDeckResource).freeze
+
+  validates :file,
+            content_type: ALLOWED_CONTENT_TYPES,
+            size: { less_than: MAX_UPLOAD_SIZE }
+
+  validates :preview,
+            content_type: 'image/png',
+            size: { less_than: MAX_UPLOAD_SIZE }
+end

--- a/app/models/teacher_resource.rb
+++ b/app/models/teacher_resource.rb
@@ -1,0 +1,23 @@
+class TeacherResource < Resource
+  ALLOWED_CONTENT_TYPES = %w(
+    application/pdf
+    application/vnd.oasis.opendocument.text
+    application/vnd.oasis.opendocument.presentation
+    image/gif
+    image/jpeg
+    image/jpg
+    image/png
+  ).freeze
+
+  MAX_UPLOAD_SIZE = 50.megabytes
+
+  validates :type, inclusion: %w(TeacherResource).freeze
+
+  validates :file,
+            content_type: ALLOWED_CONTENT_TYPES,
+            size: { less_than: MAX_UPLOAD_SIZE }
+
+  validates :preview,
+            content_type: 'image/png',
+            size: { less_than: MAX_UPLOAD_SIZE }
+end

--- a/db/migrate/20200311165603_create_resources.rb
+++ b/db/migrate/20200311165603_create_resources.rb
@@ -1,0 +1,10 @@
+class CreateResources < ActiveRecord::Migration[6.0]
+  def change
+    create_table :resources do |t|
+      t.belongs_to :activity, null: false, foreign_key: true
+      t.string :type, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_06_141111) do
+ActiveRecord::Schema.define(version: 2020_03_11_165603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -141,6 +141,14 @@ ActiveRecord::Schema.define(version: 2020_03_06_141111) do
     t.index ["unit_id"], name: "index_lessons_on_unit_id"
   end
 
+  create_table "resources", force: :cascade do |t|
+    t.bigint "activity_id", null: false
+    t.string "type", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["activity_id"], name: "index_resources_on_activity_id"
+  end
+
   create_table "subjects", force: :cascade do |t|
     t.string "name", limit: 64, null: false
     t.datetime "created_at", precision: 6, null: false
@@ -190,5 +198,6 @@ ActiveRecord::Schema.define(version: 2020_03_06_141111) do
   add_foreign_key "lesson_parts", "activities", column: "default_activity_id"
   add_foreign_key "lesson_parts", "lessons"
   add_foreign_key "lessons", "units"
+  add_foreign_key "resources", "activities"
   add_foreign_key "units", "complete_curriculum_programmes"
 end

--- a/spec/factories/pupil_resources.rb
+++ b/spec/factories/pupil_resources.rb
@@ -1,0 +1,27 @@
+FactoryBot.define do
+  attachment_path = File.join(Rails.application.root, 'spec', 'fixtures', '1px.png')
+
+  factory :pupil_resource do
+    association :activity, factory: :activity
+
+    type { "PupilResource" }
+
+    trait :with_file do
+      after :create do |pupil_resource|
+        pupil_resource.file.attach \
+          io: File.open(attachment_path),
+          filename: 'pupil-test-image.png',
+          content_type: 'image/png'
+      end
+    end
+
+    trait :with_preview do
+      after :create do |pupil_resource|
+        pupil_resource.preview.attach \
+          io: File.open(attachment_path),
+          filename: 'pupil-test-image.png',
+          content_type: 'image/png'
+      end
+    end
+  end
+end

--- a/spec/factories/slide_deck_resources.rb
+++ b/spec/factories/slide_deck_resources.rb
@@ -1,0 +1,28 @@
+FactoryBot.define do
+  slide_deck_path = File.join(Rails.application.root, 'spec', 'fixtures', 'slide_1_keyword_match_up.odp')
+  attachment_path = File.join(Rails.application.root, 'spec', 'fixtures', '1px.png')
+
+  factory :slide_deck_resource do
+    association :activity, factory: :activity
+
+    type { "SlideDeckResource" }
+
+    trait :with_file do
+      after :create do |slide_deck_resource|
+        slide_deck_resource.file.attach \
+          io: File.open(slide_deck_path),
+          filename: 'slide-1-keyword-match-up.odp',
+          content_type: 'application/vnd.oasis.opendocument.presentation'
+      end
+    end
+
+    trait :with_preview do
+      after :create do |slide_deck_resource|
+        slide_deck_resource.preview.attach \
+          io: File.open(attachment_path),
+          filename: 'slide-deck-image.png',
+          content_type: 'image/png'
+      end
+    end
+  end
+end

--- a/spec/factories/teacher_resources.rb
+++ b/spec/factories/teacher_resources.rb
@@ -1,0 +1,27 @@
+FactoryBot.define do
+  attachment_path = File.join(Rails.application.root, 'spec', 'fixtures', '1px.png')
+
+  factory :teacher_resource do
+    association :activity, factory: :activity
+
+    type { "TeacherResource" }
+
+    trait :with_file do
+      after :create do |teacher_resource|
+        teacher_resource.file.attach \
+          io: File.open(attachment_path),
+          filename: 'teacher-test-image.png',
+          content_type: 'image/png'
+      end
+    end
+
+    trait :with_preview do
+      after :create do |teacher_resource|
+        teacher_resource.preview.attach \
+          io: File.open(attachment_path),
+          filename: 'teacher-test-image.png',
+          content_type: 'image/png'
+      end
+    end
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe Activity, type: :model do
     it { is_expected.to have_many(:activity_teaching_methods).dependent(:destroy) }
     it { is_expected.to have_many(:activity_choices).dependent(:destroy) }
     it { is_expected.to have_many(:teaching_methods).through(:activity_teaching_methods) }
+    it { is_expected.to have_many(:temp_teacher_resources).conditions(type: 'TeacherResource').class_name('TeacherResource').dependent(:destroy) }
+    it { is_expected.to have_many(:temp_pupil_resources).conditions(type: 'PupilResource').class_name('PupilResource').dependent(:destroy) }
+    it { is_expected.to have_one(:temp_slide_deck).conditions(type: 'SlideDeckResource').class_name('SlideDeckResource').dependent(:destroy) }
   end
 
   describe 'validation' do

--- a/spec/models/pupil_resource_spec.rb
+++ b/spec/models/pupil_resource_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require_relative 'resource_shared_examples'
+
+describe PupilResource, type: :model do
+  let(:resource) { create :pupil_resource }
+  let(:max_upload_size) { 50.megabytes }
+  let(:allowed_content_types) do
+    %w(
+      application/pdf
+      application/vnd.oasis.opendocument.text
+      image/gif
+      image/jpeg
+      image/jpg
+      image/png
+    )
+  end
+
+  it_behaves_like 'a Resource'
+end

--- a/spec/models/resource_shared_examples.rb
+++ b/spec/models/resource_shared_examples.rb
@@ -1,0 +1,62 @@
+shared_examples 'a Resource' do
+  context 'Relationships' do
+    it { is_expected.to belong_to :activity }
+  end
+
+  context 'validations' do
+    it { is_expected.to validate_inclusion_of(:type).in_array [resource.model_name.name] }
+
+    context 'attachments' do
+      it { is_expected.to validate_size_of(:file).less_than(max_upload_size) }
+      it { is_expected.to validate_content_type_of(:file).allowing(allowed_content_types) }
+      it { is_expected.to validate_size_of(:preview).less_than(max_upload_size) }
+      it { is_expected.to validate_content_type_of(:preview).allowing('image/png') }
+    end
+  end
+
+  context 'attachments' do
+    let :attachment_path do
+      File.join(Rails.application.root, 'spec', 'fixtures', '1px.png')
+    end
+
+    let :slide_deck_path do
+      File.join(Rails.application.root, 'spec', 'fixtures', 'slide_1_keyword_match_up.odp')
+    end
+
+    context '#preview' do
+      before do
+        resource.preview.attach \
+          io: File.open(attachment_path),
+          filename: 'teacher-test-image.png',
+          content_type: 'image/png'
+      end
+
+      subject { resource.preview }
+
+      it { is_expected.to be_persisted }
+
+      it "is attached correctly" do
+        expect(subject.filename).to eq 'teacher-test-image.png'
+        expect(subject.content_type).to eq 'image/png'
+        expect(subject.download).to eq File.binread(attachment_path)
+      end
+    end
+
+    context '#file' do
+      before do
+        resource.file.attach \
+          io: File.open(slide_deck_path),
+          filename: 'slide-deck.odp',
+          content_type: 'application/vnd.oasis.opendocument.presentation'
+      end
+
+      subject { resource.file }
+
+      it "is attached correctly" do
+        expect(subject.filename).to eq 'slide-deck.odp'
+        expect(subject.content_type).to eq 'application/vnd.oasis.opendocument.presentation'
+        expect(subject.download).to eq File.binread(slide_deck_path)
+      end
+    end
+  end
+end

--- a/spec/models/slide_deck_resource_spec.rb
+++ b/spec/models/slide_deck_resource_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+require_relative 'resource_shared_examples'
+
+describe SlideDeckResource, type: :model do
+  let(:resource) { create :slide_deck_resource }
+  let(:max_upload_size) { 50.megabytes }
+  let(:allowed_content_types) do
+    %w(application/vnd.oasis.opendocument.presentation)
+  end
+
+  it_behaves_like 'a Resource'
+end

--- a/spec/models/teacher_resource_spec.rb
+++ b/spec/models/teacher_resource_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require_relative 'resource_shared_examples'
+
+describe TeacherResource, type: :model do
+  let(:resource) { create :teacher_resource }
+  let(:max_upload_size) { 50.megabytes }
+  let(:allowed_content_types) do
+    %w(
+      application/pdf
+      application/vnd.oasis.opendocument.text
+      image/gif
+      image/jpeg
+      image/jpg
+      image/png
+    )
+  end
+
+  it_behaves_like 'a Resource'
+end


### PR DESCRIPTION
We want to add previews for open office documents to the app. In order
to avoid requiring libreoffice be installed on the server we intend to
generate the previews at upload time and attach them along with the file
to the resource model.

This commit adds the new resource models and associations to activity.
Note that the associations are prefixed with `temp_` as we don't want to
remove the existing active storage associations just yet. We will once
everything is wired up.

Feel free to merge this if it's approved as there's a chain of prs built off it