### PR TITLE
Validate presence of resource file

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,23 +3,9 @@ class Activity < ApplicationRecord
   has_many :activity_teaching_methods, dependent: :destroy
   has_many :activity_choices, dependent: :destroy
   has_many :teaching_methods, through: :activity_teaching_methods
-  has_many :teacher_resources,
-           -> { where type: 'TeacherResource' },
-           class_name: 'TeacherResource',
-           dependent: :destroy,
-           inverse_of: :activity
-
-  has_many :pupil_resources,
-           -> { where type: 'PupilResource' },
-           class_name: 'PupilResource',
-           dependent: :destroy,
-           inverse_of: :activity
-
-  has_one :slide_deck_resource,
-          -> { where type: 'SlideDeckResource' },
-          class_name: 'SlideDeckResource',
-          dependent: :destroy,
-          inverse_of: :activity
+  has_many :teacher_resources, dependent: :destroy, inverse_of: :activity
+  has_many :pupil_resources, dependent: :destroy, inverse_of: :activity
+  has_one :slide_deck_resource, dependent: :destroy, inverse_of: :activity
 
   validates :lesson_part_id, presence: true
   validates :name, presence: true, length: { maximum: 128 }

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -2,4 +2,6 @@ class Resource < ApplicationRecord
   belongs_to :activity
   has_one_attached :file
   has_one_attached :preview
+
+  validates :file, attached: true
 end

--- a/app/models/slide_deck_resource.rb
+++ b/app/models/slide_deck_resource.rb
@@ -7,8 +7,6 @@ class SlideDeckResource < Resource
 
   validates :type, inclusion: %w(SlideDeckResource).freeze
 
-  # FIXME validate presence of file, there's no point having a slide deck
-  # or any other resource type if there's no file!
   validates :file,
             content_type: ALLOWED_CONTENT_TYPES,
             size: { less_than: MAX_UPLOAD_SIZE }

--- a/spec/components/activities/preview_resource_link_spec.rb
+++ b/spec/components/activities/preview_resource_link_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Activities::PreviewResourceLink, type: :component do
   context 'generated HTML' do
     let :resource do
-      create :slide_deck_resource, :with_file, :with_preview
+      create :slide_deck_resource, :with_preview
     end
 
     let :page do
@@ -11,7 +11,7 @@ describe Activities::PreviewResourceLink, type: :component do
     end
 
     context 'when resource has preview' do
-      let(:resource) { create :slide_deck_resource, :with_file, :with_preview }
+      let(:resource) { create :slide_deck_resource, :with_preview }
 
       it 'renders the correct link' do
         expect(page.find('p.preview-resource-link')).to have_link \
@@ -27,7 +27,7 @@ describe Activities::PreviewResourceLink, type: :component do
     end
 
     context 'when resource does not have a preview' do
-      let(:resource) { create :slide_deck_resource, :with_file }
+      let(:resource) { create :slide_deck_resource }
 
       it 'renders the correct link' do
         expect(page.find('p.preview-resource-link')).to have_link \

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -15,21 +15,21 @@ FactoryBot.define do
     trait :with_pupil_resources do
       after :create do |activity|
         create_list \
-          :pupil_resource, 1, :with_file, :with_preview, activity: activity
+          :pupil_resource, 1, :with_preview, activity: activity
       end
     end
 
     trait :with_teacher_resources do
       after :create do |activity|
         create_list \
-          :teacher_resource, 1, :with_file, :with_preview, activity: activity
+          :teacher_resource, 1, :with_preview, activity: activity
       end
     end
 
     trait :with_slide_deck do
       after :create do |activity|
         create \
-          :slide_deck_resource, :with_file, :with_preview, activity: activity
+          :slide_deck_resource, :with_preview, activity: activity
       end
     end
   end

--- a/spec/factories/pupil_resources.rb
+++ b/spec/factories/pupil_resources.rb
@@ -6,17 +6,15 @@ FactoryBot.define do
 
     type { "PupilResource" }
 
-    trait :with_file do
-      after :create do |pupil_resource|
-        pupil_resource.file.attach \
-          io: File.open(attachment_path),
-          filename: 'pupil-test-image.png',
-          content_type: 'image/png'
-      end
+    after :build do |pupil_resource|
+      pupil_resource.file.attach \
+        io: File.open(attachment_path),
+        filename: 'pupil-test-image.png',
+        content_type: 'image/png'
     end
 
     trait :with_preview do
-      after :create do |pupil_resource|
+      after :build do |pupil_resource|
         pupil_resource.preview.attach \
           io: File.open(attachment_path),
           filename: 'pupil-test-image.png',

--- a/spec/factories/slide_deck_resources.rb
+++ b/spec/factories/slide_deck_resources.rb
@@ -7,17 +7,15 @@ FactoryBot.define do
 
     type { "SlideDeckResource" }
 
-    trait :with_file do
-      after :create do |slide_deck_resource|
-        slide_deck_resource.file.attach \
-          io: File.open(slide_deck_path),
-          filename: 'slide-1-keyword-match-up.odp',
-          content_type: 'application/vnd.oasis.opendocument.presentation'
-      end
+    after :build do |slide_deck_resource|
+      slide_deck_resource.file.attach \
+        io: File.open(slide_deck_path),
+        filename: 'slide-1-keyword-match-up.odp',
+        content_type: 'application/vnd.oasis.opendocument.presentation'
     end
 
     trait :with_preview do
-      after :create do |slide_deck_resource|
+      after :build do |slide_deck_resource|
         slide_deck_resource.preview.attach \
           io: File.open(attachment_path),
           filename: 'slide-deck-image.png',

--- a/spec/factories/teacher_resources.rb
+++ b/spec/factories/teacher_resources.rb
@@ -6,17 +6,15 @@ FactoryBot.define do
 
     type { "TeacherResource" }
 
-    trait :with_file do
-      after :create do |teacher_resource|
-        teacher_resource.file.attach \
-          io: File.open(attachment_path),
-          filename: 'teacher-test-image.png',
-          content_type: 'image/png'
-      end
+    after :build do |teacher_resource|
+      teacher_resource.file.attach \
+        io: File.open(attachment_path),
+        filename: 'teacher-test-image.png',
+        content_type: 'image/png'
     end
 
     trait :with_preview do
-      after :create do |teacher_resource|
+      after :build do |teacher_resource|
         teacher_resource.preview.attach \
           io: File.open(attachment_path),
           filename: 'teacher-test-image.png',

--- a/spec/integration/api/v1/pupil_resources_controller_spec.rb
+++ b/spec/integration/api/v1/pupil_resources_controller_spec.rb
@@ -111,7 +111,7 @@ describe 'PupilResources' do
 
   path '/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/pupil_resources/{pupil_resource_id}' do
     let :pupil_resource do
-      create :pupil_resource, :with_file, activity: activity
+      create :pupil_resource, activity: activity
     end
 
     let :pupil_resource_id do

--- a/spec/integration/api/v1/slide_decks_controller_spec.rb
+++ b/spec/integration/api/v1/slide_decks_controller_spec.rb
@@ -86,7 +86,7 @@ describe 'Slide decks' do
       parameter name: :activity_id, in: :path, type: :string, required: true
 
       let! :slide_deck_resource do
-        create :slide_deck_resource, :with_file, :with_preview, activity: activity
+        create :slide_deck_resource, :with_preview, activity: activity
       end
 
       response '200', 'slide deck found' do
@@ -108,7 +108,7 @@ describe 'Slide decks' do
       parameter name: :activity_id, in: :path, type: :string, required: true
 
       let! :slide_deck_resource do
-        create :slide_deck_resource, :with_file, activity: activity
+        create :slide_deck_resource, activity: activity
       end
 
       response '204', 'slide deck removed' do

--- a/spec/integration/api/v1/teacher_resources_controller_spec.rb
+++ b/spec/integration/api/v1/teacher_resources_controller_spec.rb
@@ -111,7 +111,7 @@ describe 'TeacherResources' do
 
   path '/ccps/{ccp_id}/units/{unit_id}/lessons/{lesson_id}/lesson_parts/{lesson_part_id}/activities/{activity_id}/teacher_resources/{teacher_resource_id}' do
     let :teacher_resource do
-      create :teacher_resource, :with_file, activity: activity
+      create :teacher_resource, activity: activity
     end
 
     let :teacher_resource_id do

--- a/spec/presenters/teachers/lesson_contents_presenter_spec.rb
+++ b/spec/presenters/teachers/lesson_contents_presenter_spec.rb
@@ -56,15 +56,15 @@ RSpec.describe Teachers::LessonContentsPresenter do
     end
 
     let! :teacher_resource do
-      create :teacher_resource, :with_file, :with_preview, activity: activity
+      create :teacher_resource, :with_preview, activity: activity
     end
 
     let! :pupil_resource do
-      create :teacher_resource, :with_file, activity: activity
+      create :teacher_resource, activity: activity
     end
 
     let! :slide_deck do
-      create :slide_deck_resource, :with_file, :with_preview, activity: activity
+      create :slide_deck_resource, :with_preview, activity: activity
     end
 
     let :slot do

--- a/spec/utilities/resource_packager_spec.rb
+++ b/spec/utilities/resource_packager_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe(ResourcePackager) do
 
   describe '#lesson_bundle' do
     let(:activity) { create(:activity) }
-    let!(:teacher_resources) { create_list :teacher_resource, 1, :with_file, activity: activity }
-    let!(:pupil_resources) { create_list :pupil_resource, 1, :with_file, activity: activity }
+    let!(:teacher_resources) { create_list :teacher_resource, 1, activity: activity }
+    let!(:pupil_resources) { create_list :pupil_resource, 1, activity: activity }
 
     let(:teacher_attachment_filenames) do
       teacher_resources.map(&:file).map(&:filename).map(&:to_s)


### PR DESCRIPTION
Review after https://github.com/DFE-Digital/curriculum-materials/pull/142

### Context
It doesn't make sense to create a resource model without an attached file.

### Changes proposed in this pull request
Validate the resource has an attached file.
Clean up the resource association macros on activity.

### Guidance to review
Should look sensible. Manual testing, flattening the db and reseeding the app should work as before.

