### PR TITLE
Require basic auth only in teacher/pages controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
-  include HTTPAuth
-
   before_action :set_raven_context
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  include HTTPAuth
+
   PAGES = %w(
     how-to-get-access
   ).freeze

--- a/app/controllers/teachers/base_controller.rb
+++ b/app/controllers/teachers/base_controller.rb
@@ -1,5 +1,7 @@
 module Teachers
   class BaseController < ApplicationController
+    include HTTPAuth
+
     before_action :ensure_token_exists
 
     def current_teacher


### PR DESCRIPTION
It's not necessary for the API to be proteced via HTTP auth now we have bearer-based authentication.

The two schemes in combination appear to tread on each others toes due to them [both wanting to set the `Authorization` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#Authentication_schemes).