### PR TITLE
🐛fix when lesson has no slide_desks

### DIFF
--- a/app/lib/presentation_merger.rb
+++ b/app/lib/presentation_merger.rb
@@ -102,9 +102,9 @@ private
         @output_stream.puts line
       end
       stderr_str = stderr.read
-      @output_stream.close_write
       @output_stream.flush
       @output_stream.rewind
+      @output_stream.close_write
       wait_thr.value
     end
     unless exit_status.success?

--- a/app/lib/presentation_merger.rb
+++ b/app/lib/presentation_merger.rb
@@ -96,12 +96,15 @@ private
     command = "./node_modules/.bin/presentation-merger #{file_paths}"
 
     stderr_str = ''
+    @output_stream.binmode
     exit_status = Open3.popen3(command) do |_stdin, stdout, stderr, wait_thr|
       while (line = stdout.gets)
         @output_stream.puts line
       end
       stderr_str = stderr.read
       @output_stream.close_write
+      @output_stream.flush
+      @output_stream.rewind
       wait_thr.value
     end
     unless exit_status.success?

--- a/app/utilities/resource_packager.rb
+++ b/app/utilities/resource_packager.rb
@@ -24,7 +24,9 @@ private
   end
 
   def slide_deck_tempfiles
-    slide_decks.map { |activity| activity.attachment.open { |f| f } if activity.attached? }.compact
+    slide_decks
+      .select { |slide_deck| slide_deck.attached? }
+      .map { |activity| activity.attachment.open { |f| f } }
   end
 
   def combined_slide_deck

--- a/app/utilities/resource_packager.rb
+++ b/app/utilities/resource_packager.rb
@@ -52,9 +52,7 @@ private
     end
     @combined_slide_decks
   ensure
-    slide_decks_tempfiles.each do |file|
-      file.close!
-    end
+    slide_decks_tempfiles.inject(&:close!)
     @combined_slide_decks
   end
 

--- a/app/utilities/resource_packager.rb
+++ b/app/utilities/resource_packager.rb
@@ -19,11 +19,17 @@ private
     @lesson_parts.values
   end
 
+  def slide_decks
+    activities.map(&:slide_deck)
+  end
+
   def slide_deck_tempfiles
-    activities.map { |activity| activity.slide_deck_resource.file.attachment.open { |f| f } }
+    slide_decks.map { |activity| activity.attachment.open { |f| f } if activity.attached? }.compact
   end
 
   def combined_slide_deck
+    return nil if slide_deck_tempfiles.empty?
+
     PresentationMerger.write_buffer do |pres|
       slide_deck_tempfiles.each do |file|
         pres << file
@@ -53,7 +59,9 @@ private
   end
 
   def add_presentation_to_zip(zip)
-    zip.put_next_entry('teacher/presentation.odp')
-    zip.print(combined_slide_deck)
+    if combined_slide_deck
+      zip.put_next_entry('teacher/presentation.odp')
+      zip.print(combined_slide_deck)
+    end
   end
 end

--- a/spec/utilities/resource_packager_spec.rb
+++ b/spec/utilities/resource_packager_spec.rb
@@ -40,15 +40,14 @@ RSpec.describe(ResourcePackager) do
         returned_teacher_resources = zipped_file_names.select { |fn| fn.starts_with? 'teacher' }
         returned_pupil_resources = zipped_file_names.select { |fn| fn.starts_with? 'pupil' }
 
-        # FIXME the final presentation is being added into the teacher directory
-        # it should be added at the top level of the zip.
-        expect(teacher_attachment_filenames + ['presentation.odp']).to match_array(strip_paths(returned_teacher_resources))
+        expect(teacher_attachment_filenames).to match_array(strip_paths(returned_teacher_resources))
         expect(pupil_attachment_filenames).to match_array(strip_paths(returned_pupil_resources))
+        expect(zipped_file_names).to include("#{download.lesson.name.parameterize}.odp")
       end
     end
 
     it 'doesn\'t include any presentations where there\'s no slide decks' do
-      activity.slide_deck.detach
+      slide_deck_resource.file.detach
 
       Zip::File.open_buffer(subject) do |zip|
         zip.map(&:name).each do |name|

--- a/spec/utilities/resource_packager_spec.rb
+++ b/spec/utilities/resource_packager_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe(ResourcePackager) do
       end
     end
 
-    it 'doesn\'t include any presentations where theres no slide decks' do
+    it 'doesn\'t include any presentations where there\'s no slide decks' do
       activity.slide_deck.detach
 
       Zip::File.open_buffer(subject) do |zip|

--- a/spec/utilities/resource_packager_spec.rb
+++ b/spec/utilities/resource_packager_spec.rb
@@ -46,5 +46,15 @@ RSpec.describe(ResourcePackager) do
         expect(pupil_attachment_filenames).to match_array(strip_paths(returned_pupil_resources))
       end
     end
+
+    it 'doesn\'t include any presentations where theres no slide decks' do
+      activity.slide_deck.detach
+
+      Zip::File.open_buffer(subject) do |zip|
+        zip.map(&:name).each do |name|
+          expect(name).not_to end_with(".odp")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION

### Context

Bug Report: https://sentry.io/organizations/dfe-curriculum-materials/issues/1568426357/?project=1883970&query=is%3Aunresolved

### Changes proposed in this pull request

Check if lesson parts contain any slide desk before trying to attach a slide deck.

### Guidance to review

```bash
git checkout bugfix/staging-y
bundle exec rspec spec/utilities/resource_packager_spec.rb:82
```
