### PR TITLE
Discard failed jobs

### DIFF
--- a/spec/jobs/download_job_spec.rb
+++ b/spec/jobs/download_job_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe DownloadJob, type: :job do
+  before { ActiveJob::Base.queue_adapter = :test }
   let(:download) { create(:download) }
 
   describe '#perform_later' do
-    before { ActiveJob::Base.queue_adapter = :test }
-
     it "enqueues jobs" do
       expect { DownloadJob.perform_later(download) }.to have_enqueued_job
     end
@@ -36,15 +35,13 @@ RSpec.describe DownloadJob, type: :job do
       allow(ResourcePackager).to receive(:new).and_raise(StandardError)
     end
 
-    subject { described_class.perform_now download }
+    before { described_class.perform_now download }
 
     it 'notifies sentry' do
-      expect { subject }.to raise_error StandardError
       expect(Raven).to have_received(:capture_exception).with StandardError
     end
 
     it 'marks the job as failed' do
-      expect { subject }.to raise_error StandardError
       expect(download.reload).to be_in_state :failed
     end
   end


### PR DESCRIPTION
If a download job has failed we don't want it to retry, instead we'll
let the teacher manually trigger a new job.

### Context
Noticed a sentry error (https://sentry.io/organizations/dfe-curriculum-materials/issues/1568646312/?project=1883970&query=is%3Aunresolved) where failed jobs being retried was causing statesman to throw when attempting to transition failed -> failed.

### Changes proposed in this pull request
Don't retry failed jobs, we just want to discard them and let the teacher retry the download manually.

### Guidance to review
Manual testing if required:
Update the download job to throw an error.
Expect to see delayed job logs showing the job completed rather than failed.
Expect the download to be marked as failed.

closes #152 