### PR TITLE
🐛 Download failing due to wrong enumerator

### DIFF
--- a/app/utilities/resource_packager.rb
+++ b/app/utilities/resource_packager.rb
@@ -28,7 +28,7 @@ private
   end
 
   def slide_decks_tempfiles
-    slide_decks
+    @slide_decks_tempfiles ||= slide_decks
       .select { |slide_deck| slide_deck.file.attached? }
       .map do |slide_deck|
         file = Tempfile.open('ResourcePackager-') do |tempfile|
@@ -57,7 +57,7 @@ private
   end
 
   def has_slide_decks?
-    slide_decks_tempfiles.any?
+    slide_decks.any? { |slide_deck| slide_deck.file.attached? }
   end
 
   def pupil_resource_blobs

--- a/app/utilities/resource_packager.rb
+++ b/app/utilities/resource_packager.rb
@@ -52,7 +52,7 @@ private
     end
     @combined_slide_decks
   ensure
-    slide_decks_tempfiles.inject(&:close!)
+    slide_decks_tempfiles.each(&:close!)
     @combined_slide_decks
   end
 


### PR DESCRIPTION
I incorrectly used `inject` when the intent is `each` for closing each tempfile after downloading and processing a presentation. 

Also found a quick performance improvement to avoid re-downloading assets form storage into tempfiles.