### PR TITLE
Add support email link to the phase banner

### DIFF
--- a/app/views/layouts/shared/_phase_banner.slim
+++ b/app/views/layouts/shared/_phase_banner.slim
@@ -1,10 +1,10 @@
 .govuk-phase-banner
   p.govuk-phase-banner__content
     strong.govuk-tag.govuk-phase-banner__content__tag
-      | beta 
+      | beta
     span.govuk-phase-banner__text
       | This is a new service – your
-      =<> link_to 'feedback', '#'
+      =<> mail_to('curriculum-materials@digital.education.gov.uk', 'feedback', class: 'govuk-link')
       | will help us to improve it.
 
   - if @current_teacher.present?

--- a/spec/features/teachers/feedback_spec.rb
+++ b/spec/features/teachers/feedback_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.feature "Emailing feedback", type: :feature do
+  let(:email_address) { 'curriculum-materials@digital.education.gov.uk' }
+  include_context 'logged in teacher'
+
+  before { visit(teachers_home_path) }
+
+  specify 'there should be a feedback email link in the phase banner' do
+    within('.govuk-phase-banner') do
+      expect(page).to have_link('feedback', href: "mailto:" + email_address)
+    end
+  end
+end


### PR DESCRIPTION
Add email link to the phase banner. The email address is our shared inbox `curriculum-materials@digital.education.gov.uk`.
