### PR TITLE
Clean up old downloaded lesson_bundles

### DIFF
--- a/app/models/download_state_machine.rb
+++ b/app/models/download_state_machine.rb
@@ -4,10 +4,16 @@ class DownloadStateMachine
   state :pending, initial: true
   state :completed
   state :failed
+  state :cleaned_up
 
   transition from: :pending, to: %i(completed failed)
+  transition from: :completed, to: :cleaned_up
 
   guard_transition from: :pending, to: :completed do |download|
     download.lesson_bundle.attached?
+  end
+
+  guard_transition from: :completed, to: :cleaned_up do |download|
+    !download.lesson_bundle.attached?
   end
 end

--- a/app/models/download_transition.rb
+++ b/app/models/download_transition.rb
@@ -1,14 +1,9 @@
 class DownloadTransition < ApplicationRecord
-  # If your transition table doesn't have the default `updated_at` timestamp column,
-  # you'll need to configure the `updated_timestamp_column` option, setting it to
-  # another column name (e.g. `:updated_on`) or `nil`.
-  #
-  # self.updated_timestamp_column = :updated_on
-  # self.updated_timestamp_column = nil
-
   belongs_to :download, inverse_of: :download_transitions
 
   after_destroy :update_most_recent, if: :most_recent?
+
+  scope :completed, -> { where most_recent: true, to_state: 'completed' }
 
 private
 

--- a/lib/tasks/downloads.rake
+++ b/lib/tasks/downloads.rake
@@ -1,0 +1,13 @@
+desc "Removes attachments from S3 for all 'historic' downloads"
+namespace :downloads do
+  namespace :lesson_bundles do
+    task clean_up: :environment do
+      Download.to_clean_up.find_in_batches(batch_size: 10) do |downloads|
+        downloads.each do |download|
+          download.lesson_bundle.purge
+          download.transition_to! :cleaned_up
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/downloads.rb
+++ b/spec/factories/downloads.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     association :teacher
     association :lesson
 
+    trait :historic do
+      created_at { Download::LESSON_BUNDLE_TTL.ago }
+    end
+
     trait :completed do
       after :create do |download|
         lesson_bundle_path =  \
@@ -20,6 +24,15 @@ FactoryBot.define do
     trait :failed do
       after :create do |download|
         download.transition_to! :failed
+      end
+    end
+
+    trait :cleaned_up do
+      completed
+
+      after :create do |download|
+        download.lesson_bundle.purge
+        download.transition_to! :cleaned_up
       end
     end
   end

--- a/spec/lib/tasks/downloads_spec.rb
+++ b/spec/lib/tasks/downloads_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'downloads:lesson_bundles:clean_up' do
+  let!(:recently_completed) { create :download, :completed }
+  let!(:historic_completed) { create :download, :completed, :historic }
+
+  before { Rails.application.load_tasks }
+  before { Rake::Task['downloads:lesson_bundles:clean_up'].invoke }
+
+  it 'purges any historic downloads' do
+    expect(historic_completed.reload.lesson_bundle).not_to be_attached
+  end
+
+  it 'doesnt purge any other downloads' do
+    expect(recently_completed.reload.lesson_bundle).to be_attached
+  end
+end


### PR DESCRIPTION
Clean up old downloaded lesson_bundles

### Context
In order to keep our S3 bucket clean we're adding a rake task to purge
old lesson_bundle zips from S3.
This task will be called once a day from the heroku scheduler.

### Changes proposed in this pull request
Adds a new scope to downloads to return the downloads that need to be cleaned up.
Adds a rake task to remove old lesson_bundle zips from S3.

### Guidance to reviews
Should look sensible.
When we're back on the project I'll set up heroku scheduler to run the task once a day at some point around midnight.
