### PR TITLE
Fix CVE-2020-7598

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -963,13 +963,13 @@
       }
     },
     "@dfe-digital/presentation-merger": {
-      "version": "0.0.1-alpha.5",
-      "resolved": "https://npm.pkg.github.com/download/@dfe-digital/presentation-merger/0.0.1-alpha.5/00bda8ece9c29a82eee69bf297861e2a48783d160c954456b10a98a3f57f0fab",
-      "integrity": "sha512-8SRWMb7w7bA5/dJ1vpSxX3xzwUYFkHnmUHgBtCm7+vk3mP/92TUAJwkP03xRxTDsiGqukQR0+tvNjm6hifO5/w==",
+      "version": "0.0.1-alpha.7",
+      "resolved": "https://npm.pkg.github.com/download/@dfe-digital/presentation-merger/0.0.1-alpha.7/9ed1e5050ab7150ce08d9aa10dcac43739a815c255fc72bb07ac70cd3f55f61c",
+      "integrity": "sha512-cVt5A2WApSKrdcxta0CCp+AYXtVz367faE4Tu8CeQwLsNAvU9gxXP3bxrjuYMahtdDyQ3uAL+6FnvG5HncfD0w==",
       "requires": {
         "@prettier/plugin-xml": "^0.7.2",
         "chalk": "^3.0.0",
-        "commander": "^4.1.1",
+        "commander": "^5.0.0",
         "debug": "^4.1.1",
         "fast-xml-parser": "^3.16.0",
         "jszip": "^3.2.2",
@@ -2508,9 +2508,9 @@
       }
     },
     "commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
+      "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ=="
     },
     "common-tags": {
       "version": "1.8.0",
@@ -6626,9 +6626,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "heroku-prebuild": "echo \"//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}\" >> .npmrc"
   },
   "dependencies": {
-    "@dfe-digital/presentation-merger": "^0.0.1-alpha.4",
+    "@dfe-digital/presentation-merger": "^0.0.1-alpha.7",
     "@rails/webpacker": "^4.2.2",
     "govuk-frontend": "^3.6.0",
     "rails-ujs": "^5.2.4",


### PR DESCRIPTION
### Context

Security alert CVE-2020-7598 on `minimist` deep dependency.

### Changes proposed in this pull request

Bump `@dfe-digital/presentation-merger`

### Guidance to review

Tests work as expected.

