### PR TITLE
Adds spec for polling tag

### DIFF
--- a/spec/controllers/teachers/downloads_controller_spec.rb
+++ b/spec/controllers/teachers/downloads_controller_spec.rb
@@ -39,6 +39,12 @@ describe Teachers::DownloadsController, type: :request do
     context 'when download is pending' do
       let(:download) { create :download, teacher: teacher }
       it { is_expected.to render_template :pending }
+
+      it "include the polling tag" do
+        subject
+        expect(response.body).to \
+          include '<meta content="5" http-equiv="refresh" />'
+      end
     end
 
     context 'when download has completed' do


### PR DESCRIPTION
Make sure the polling tag hasn't been deleted

### Context
Managed to delete the polling tag and that got deployed to staging 🤦‍♂ 
Pushed a bugfix straight to deploy

### Changes proposed in this pull request
Adds a spec to make sure that doesn't happen again!

### Guidance to review
Should look sensible
