### PR TITLE
Bugfix slide deck no file

### DIFF
--- a/app/utilities/resource_packager.rb
+++ b/app/utilities/resource_packager.rb
@@ -24,7 +24,7 @@ private
   end
 
   def slide_decks
-    activities.map(&:slide_deck_resource)
+    activities.map(&:slide_deck_resource).compact
   end
 
   def slide_decks_tempfiles

--- a/spec/utilities/resource_packager_spec.rb
+++ b/spec/utilities/resource_packager_spec.rb
@@ -9,24 +9,23 @@ RSpec.describe(ResourcePackager) do
   it { is_expected.to respond_to(:lesson_bundle) }
 
   describe '#lesson_bundle' do
-    let(:activity) { create(:activity) }
-    let!(:teacher_resources) { create_list :teacher_resource, 1, activity: activity }
-    let!(:pupil_resources) { create_list :pupil_resource, 1, activity: activity }
-    let!(:slide_deck_resource) { create :slide_deck_resource, activity: activity }
+    let(:activity) { create(:activity, :with_pupil_resources, :with_teacher_resources, :with_slide_deck) }
+    let(:lesson_part) { activity.lesson_part }
+    let(:lesson) { lesson_part.lesson }
 
     let(:teacher_attachment_filenames) do
-      teacher_resources.map(&:file).map(&:filename).map(&:to_s)
+      activity.teacher_resources.map(&:file).map(&:filename).map(&:to_s)
     end
 
     let(:pupil_attachment_filenames) do
-      pupil_resources.map(&:file).map(&:filename).map(&:to_s)
+      activity.pupil_resources.map(&:file).map(&:filename).map(&:to_s)
     end
 
     let(:slide_deck_attachment_filename) do
       'presentation.odp'
     end
 
-    let(:download) { create(:download, lesson: activity.lesson_part.lesson) }
+    let(:download) { create(:download, lesson: lesson) }
     subject { ResourcePackager.new(download).lesson_bundle }
 
     def strip_paths(entries)
@@ -47,7 +46,7 @@ RSpec.describe(ResourcePackager) do
     end
 
     it 'doesn\'t include any presentations where there\'s no slide decks' do
-      slide_deck_resource.file.detach
+      activity.slide_deck_resource.file.detach
 
       Zip::File.open_buffer(subject) do |zip|
         zip.map(&:name).each do |name|

--- a/spec/utilities/resource_packager_spec.rb
+++ b/spec/utilities/resource_packager_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe(ResourcePackager) do
+  def strip_paths(entries)
+    entries.map { |tr| File.basename(tr) }
+  end
+
   let(:download) { create(:download) }
 
   subject { ResourcePackager.new(download) }
@@ -9,10 +13,6 @@ RSpec.describe(ResourcePackager) do
   it { is_expected.to respond_to(:lesson_bundle) }
 
   describe '#lesson_bundle' do
-    let(:activity) { create(:activity, :with_pupil_resources, :with_teacher_resources, :with_slide_deck) }
-    let(:lesson_part) { activity.lesson_part }
-    let(:lesson) { lesson_part.lesson }
-
     let(:teacher_attachment_filenames) do
       activity.teacher_resources.map(&:file).map(&:filename).map(&:to_s)
     end
@@ -25,32 +25,53 @@ RSpec.describe(ResourcePackager) do
       'presentation.odp'
     end
 
-    let(:download) { create(:download, lesson: lesson) }
+    let!(:download) { create(:download, lesson: lesson) }
+
     subject { ResourcePackager.new(download).lesson_bundle }
 
-    def strip_paths(entries)
-      entries.map { |tr| File.basename(tr) }
-    end
+    context 'activity has slide deck' do
+      let!(:activity) { create(:activity, :with_pupil_resources, :with_teacher_resources, :with_slide_deck) }
+      let!(:lesson_part) { activity.lesson_part }
+      let!(:lesson) { lesson_part.lesson }
 
-    specify 'all attachments should be added to the zip file' do
-      Zip::File.open_buffer(subject) do |zip|
-        zipped_file_names = *zip.map(&:name)
+      specify 'all attachments should be added to the zip file' do
+        Zip::File.open_buffer(subject) do |zip|
+          zipped_file_names = *zip.map(&:name)
 
-        returned_teacher_resources = zipped_file_names.select { |fn| fn.starts_with? 'teacher' }
-        returned_pupil_resources = zipped_file_names.select { |fn| fn.starts_with? 'pupil' }
+          returned_teacher_resources = zipped_file_names.select { |fn| fn.starts_with? 'teacher' }
+          returned_pupil_resources = zipped_file_names.select { |fn| fn.starts_with? 'pupil' }
 
-        expect(teacher_attachment_filenames).to match_array(strip_paths(returned_teacher_resources))
-        expect(pupil_attachment_filenames).to match_array(strip_paths(returned_pupil_resources))
-        expect(zipped_file_names).to include("#{download.lesson.name.parameterize}.odp")
+          expect(teacher_attachment_filenames).to match_array(strip_paths(returned_teacher_resources))
+          expect(pupil_attachment_filenames).to match_array(strip_paths(returned_pupil_resources))
+          expect(zipped_file_names).to include("#{download.lesson.name.parameterize}.odp")
+        end
+      end
+
+      it "doesn't include any presentations where there's no slide decks" do
+        activity.slide_deck_resource.file.detach
+
+        Zip::File.open_buffer(subject) do |zip|
+          zip.map(&:name).each do |name|
+            expect(name).not_to end_with(".odp")
+          end
+        end
       end
     end
 
-    it 'doesn\'t include any presentations where there\'s no slide decks' do
-      activity.slide_deck_resource.file.detach
+    context "activity doesn't have a slide deck" do
+      let!(:activity) { create :activity, :with_pupil_resources, :with_teacher_resources }
+      let!(:lesson_part) { activity.lesson_part }
+      let!(:lesson) { lesson_part.lesson }
 
-      Zip::File.open_buffer(subject) do |zip|
-        zip.map(&:name).each do |name|
-          expect(name).not_to end_with(".odp")
+      specify 'all attachments should be added to the zip file' do
+        Zip::File.open_buffer(subject) do |zip|
+          zipped_file_names = *zip.map(&:name)
+
+          returned_teacher_resources = zipped_file_names.select { |fn| fn.starts_with? 'teacher' }
+          returned_pupil_resources = zipped_file_names.select { |fn| fn.starts_with? 'pupil' }
+
+          expect(teacher_attachment_filenames).to match_array(strip_paths(returned_teacher_resources))
+          expect(pupil_attachment_filenames).to match_array(strip_paths(returned_pupil_resources))
         end
       end
     end


### PR DESCRIPTION
### Context
Fixes sentry error on staging.
Mapping through activities slide_decks keeps nil values which then explode when we attempt to get their file

### Changes proposed in this pull request
Compact the slide_decks array to remove any nils

### Guidance to review
Should look sensible
