### PR TITLE
🐛 e2e est unit contains lessons

### DIFF
--- a/cypress/integration/Unit.spec.js
+++ b/cypress/integration/Unit.spec.js
@@ -2,12 +2,12 @@ describe("Unit", () => {
   beforeEach(() => {
     cy.loadLessonFixtures();
     cy.login();
-    cy.shouldHaveHeaderAndFooter();
   });
 
   it("Displays each unit", () => {
     cy.get("@units").each(unit => {
       cy.visit(`/teachers/units/${unit.id}`);
+      cy.shouldHaveHeaderAndFooter();
       cy.get(".siblings > ol > li.current").should("contain.text", unit.name);
       cy.get(".govuk-heading-l").should("have.text", unit.name);
       cy.get(".govuk-grid-column-two-thirds").within(() => {
@@ -18,20 +18,22 @@ describe("Unit", () => {
   });
 
   it("Displays lessons for each unit", () => {
-    let unitsCovered = [];
-    cy.get("@lessons").each(lesson => {
-      if (unitsCovered.includes(lesson.unit_id)) {
-        return;
-      }
-      unitsCovered.push(lesson.unit_id);
-      cy.visit(`/teachers/units/${lesson.unit_id}`);
-      cy.get(".govuk-table").should("exist");
-      cy.get(".govuk-table__body tr").within(() => {
-        cy.get("td").should("contain.text", lesson.learning_objective);
-        cy.get("a")
-          .should("have.attr", "href")
-          .should("equal", `/teachers/lessons/${lesson.id}`);
-      });
+    cy.get("@units").each((unit) => {
+      cy.visit(`/teachers/units/${unit.id}`);
+      cy.shouldHaveHeaderAndFooter();
+      cy.get("@lessons").each((lesson, index) => {
+        if(lesson.unit_id !== unit.id) {
+          // skip if this lesson doesn't belong to the unit.
+          return;
+        }
+        cy.get(".govuk-table").should("exist");
+        cy.get(".govuk-table__body tr").eq(index).within(() => {
+          cy.get("td").should("contain.text", lesson.learning_objective);
+          cy.get("a")
+            .should("have.attr", "href")
+            .should("equal", `/teachers/lessons/${lesson.id}`);
+        });
+      })
     });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -43,11 +43,13 @@ Cypress.Commands.add("loadUnitFixtures", () => {
     })
       .its("body")
       .then(body => {
-        body = body.map(unit => {
-          unit.ccp_id = ccp.id;
-          return unit;
-        });
-        body.forEach(i => units.push(i));
+        body
+          .map(unit => {
+            unit.ccp_id = ccp.id;
+            return unit;
+          })
+          .sort((a, b) => (a.position > b.position ? 1 : -1))
+          .forEach(i => units.push(i));
       });
   });
   cy.wrap(units).as("units");
@@ -63,12 +65,14 @@ Cypress.Commands.add("loadLessonFixtures", () => {
     })
       .its("body")
       .then(lessons => {
-        lessons = lessons.map(lesson => {
-          lesson.ccp_id = unit.ccp_id;
-          lesson.unit_id = unit.id;
-          return lesson;
-        });
-        lessons.forEach(i => array.push(i));
+        lessons
+          .map(lesson => {
+            lesson.ccp_id = unit.ccp_id;
+            lesson.unit_id = unit.id;
+            return lesson;
+          })
+          .sort((a, b) => (a.position > b.position ? 1 : -1))
+          .forEach(i => array.push(i));
       });
   });
   cy.wrap(array).as("lessons");


### PR DESCRIPTION
### Context

E2E CI build fails due to the detection of the wrong lesson in a unit in the testing. 

The application is rendering as expected. 

### Changes proposed in this pull request

Refactor the unit test to cover the assertions of lessons in the given unit.
Sort the Unit and Lessons by position.

### Guidance to review

```bash
git checkout testing/bugfix-dynamic-unit-lesson-id
bundle exec rails server --port 3000
CYPRESS_BASE_URL=http://localhost:3000 npm run cy:open
```

Alternatively, check this [CI build is successful](https://github.com/DFE-Digital/curriculum-materials/runs/536644653)

